### PR TITLE
Add kestrel & unsafeTap, introduce granular `any` syntax

### DIFF
--- a/shared/src/main/scala/mouse/any.scala
+++ b/shared/src/main/scala/mouse/any.scala
@@ -7,4 +7,12 @@ trait AnySyntax {
 final class AnyOps[A](val oa: A) extends AnyVal {
   @inline def |>[B] (f: A => B) = f(oa)
   @inline def thrush[B] (f: A => B) = f(oa)
+  @inline def <|(f: A => Unit): A = {
+    f(oa)
+    oa
+  }
+  @inline def unsafeTap(f: A => Unit): A = {
+    f(oa)
+    oa
+  }
 }

--- a/shared/src/main/scala/mouse/package.scala
+++ b/shared/src/main/scala/mouse/package.scala
@@ -1,5 +1,6 @@
 package object mouse {
   object all extends AllSyntax
+  object any extends AnySyntax
   object option extends OptionSyntax
   object boolean extends BooleanSyntax
   object string extends StringSyntax


### PR DESCRIPTION
This PR adds kestrel (<|) and unsafeTap to `any` syntax, which are intended to be removed from cats-collections (https://github.com/typelevel/cats-collections/issues/105). Also, now it is possible to import `mouse.any._`