### PR TITLE
Extends MapOps

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,8 +3,8 @@ import sbt._
 import sbtcrossproject.crossProject
 
 lazy val commonSettings = Def.settings(
-  scalaVersion := "2.12.7",
-  crossScalaVersions := Seq("2.11.12", "2.12.7", "2.13.0-M5")
+  scalaVersion := "2.12.8",
+  crossScalaVersions := Seq("2.11.12", "2.12.8", "2.13.0-M5")
 )
 
 lazy val root = project.in(file(".")).aggregate(js, jvm).

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.1
+sbt.version=1.2.7

--- a/shared/src/main/scala/mouse/map.scala
+++ b/shared/src/main/scala/mouse/map.scala
@@ -1,5 +1,7 @@
 package mouse
 
+import cats.{Applicative, Semigroup}
+
 trait MapSyntax {
   implicit final def mapSyntaxMouse[A, B](map: Map[A, B]): MapOps[A, B] = new MapOps(map)
 }
@@ -7,4 +9,12 @@ trait MapSyntax {
 final class MapOps[A, B](private val map: Map[A, B]) extends AnyVal {
 
   def mapKeys[C](f: A => C): Map[C, B] = map.map { case (a, b) => (f(a), b) }
+
+  def updateKey(key: A, f: B => B): Map[A, B] = map.get(key).fold(map)(value => map.updated(key, f(value)))
+
+  def updateKeyF[F[_]](key: A, f: B => F[B])(implicit F: Applicative[F]): F[Map[A, B]] =
+    map.get(key).fold(F.pure(map))(value => F.map(f(value))(result => map.updated(key, result)))
+
+  def updateKeyCombine(key: A, add: B)(implicit sg: Semigroup[B]): Map[A, B] =
+    map.get(key).fold(map)(value => map.updated(key, sg.combine(value, add)))
 }

--- a/shared/src/main/scala/mouse/map.scala
+++ b/shared/src/main/scala/mouse/map.scala
@@ -10,11 +10,11 @@ final class MapOps[A, B](private val map: Map[A, B]) extends AnyVal {
 
   def mapKeys[C](f: A => C): Map[C, B] = map.map { case (a, b) => (f(a), b) }
 
-  def updateKey(key: A, f: B => B): Map[A, B] = map.get(key).fold(map)(value => map.updated(key, f(value)))
+  def updateAtKey(key: A, f: B => B): Map[A, B] = map.get(key).fold(map)(value => map.updated(key, f(value)))
 
-  def updateKeyF[F[_]](key: A, f: B => F[B])(implicit F: Applicative[F]): F[Map[A, B]] =
+  def updateAtKeyF[F[_]](key: A, f: B => F[B])(implicit F: Applicative[F]): F[Map[A, B]] =
     map.get(key).fold(F.pure(map))(value => F.map(f(value))(result => map.updated(key, result)))
 
-  def updateKeyCombine(key: A, add: B)(implicit sg: Semigroup[B]): Map[A, B] =
-    map.get(key).fold(map)(value => map.updated(key, sg.combine(value, add)))
+  def updateAtKeyCombine(key: A, add: B)(implicit sg: Semigroup[B]): Map[A, B] =
+    map.get(key).fold(map + (key -> add))(value => map.updated(key, sg.combine(value, add)))
 }

--- a/shared/src/test/scala/mouse/MapSyntaxTest.scala
+++ b/shared/src/test/scala/mouse/MapSyntaxTest.scala
@@ -9,21 +9,21 @@ class MapSyntaxTest extends MouseSuite {
   Map[Int, Int]().mapKeys(identity) shouldEqual Map[Int, Int]()
 
 
-  Map(1 -> 2, 3 -> 4).updateKey(3, _ * 2) shouldEqual Map(1 -> 2, 3 -> 8)
+  Map(1 -> 2, 3 -> 4).updateAtKey(3, _ * 2) shouldEqual Map(1 -> 2, 3 -> 8)
 
-  Map(1 -> 2, 3 -> 4).updateKey(42, _ * 2) shouldEqual Map(1 -> 2, 3 -> 4)
+  Map(1 -> 2, 3 -> 4).updateAtKey(42, _ * 2) shouldEqual Map(1 -> 2, 3 -> 4)
 
-  Map(1 -> 2, 3 -> 4).updateKey(3, identity) shouldEqual Map(1 -> 2, 3 -> 4)
-
-
-  Map(1 -> 2, 3 -> 4).updateKeyCombine(3, 5) shouldEqual Map(1 -> 2, 3 -> 9)
-
-  Map(1 -> 2, 3 -> 4).updateKeyCombine(42, 5) shouldEqual Map(1 -> 2, 3 -> 4)
+  Map(1 -> 2, 3 -> 4).updateAtKey(3, identity) shouldEqual Map(1 -> 2, 3 -> 4)
 
 
-  Map(1 -> 2, 3 -> 4).updateKeyF(3, Option(_)) shouldEqual Some(Map(1 -> 2, 3 -> 4))
+  Map(1 -> 2, 3 -> 4).updateAtKeyCombine(3, 5) shouldEqual Map(1 -> 2, 3 -> 9)
 
-  Map(1 -> 2, 3 -> 4).updateKeyF(3, i => Option(i * 2)) shouldEqual Some(Map(1 -> 2, 3 -> 8))
+  Map(1 -> 2, 3 -> 4).updateAtKeyCombine(42, 5) shouldEqual Map(1 -> 2, 3 -> 4, 42 -> 5)
 
-  Map(1 -> 2, 3 -> 4).updateKeyF(42, Option(_)) shouldEqual Some(Map(1 -> 2, 3 -> 4))
+
+  Map(1 -> 2, 3 -> 4).updateAtKeyF(3, Option(_)) shouldEqual Some(Map(1 -> 2, 3 -> 4))
+
+  Map(1 -> 2, 3 -> 4).updateAtKeyF(3, i => Option(i * 2)) shouldEqual Some(Map(1 -> 2, 3 -> 8))
+
+  Map(1 -> 2, 3 -> 4).updateAtKeyF(42, Option(_)) shouldEqual Some(Map(1 -> 2, 3 -> 4))
 }

--- a/shared/src/test/scala/mouse/MapSyntaxTest.scala
+++ b/shared/src/test/scala/mouse/MapSyntaxTest.scala
@@ -7,4 +7,23 @@ class MapSyntaxTest extends MouseSuite {
   Map(1 -> 2, 3 -> 4).mapKeys(identity) shouldEqual Map(1 -> 2, 3 -> 4)
 
   Map[Int, Int]().mapKeys(identity) shouldEqual Map[Int, Int]()
+
+
+  Map(1 -> 2, 3 -> 4).updateKey(3, _ * 2) shouldEqual Map(1 -> 2, 3 -> 8)
+
+  Map(1 -> 2, 3 -> 4).updateKey(42, _ * 2) shouldEqual Map(1 -> 2, 3 -> 4)
+
+  Map(1 -> 2, 3 -> 4).updateKey(3, identity) shouldEqual Map(1 -> 2, 3 -> 4)
+
+
+  Map(1 -> 2, 3 -> 4).updateKeyCombine(3, 5) shouldEqual Map(1 -> 2, 3 -> 9)
+
+  Map(1 -> 2, 3 -> 4).updateKeyCombine(42, 5) shouldEqual Map(1 -> 2, 3 -> 4)
+
+
+  Map(1 -> 2, 3 -> 4).updateKeyF(3, Option(_)) shouldEqual Some(Map(1 -> 2, 3 -> 4))
+
+  Map(1 -> 2, 3 -> 4).updateKeyF(3, i => Option(i * 2)) shouldEqual Some(Map(1 -> 2, 3 -> 8))
+
+  Map(1 -> 2, 3 -> 4).updateKeyF(42, Option(_)) shouldEqual Some(Map(1 -> 2, 3 -> 4))
 }


### PR DESCRIPTION
This PR adds three more convenience methods for `Map[A, B]` for updating single keys using a function, a semigroup or an effectful function (used `Option` in the tests, but works for any `Applicative`, most useful with monads like `cats.effect.IO`).

Also bumps Scala version to 2.12.8 and sbt to 1.2.7.