### PR TITLE
make syntax extensions not leak the actual object

### DIFF
--- a/shared/src/main/scala/mouse/any.scala
+++ b/shared/src/main/scala/mouse/any.scala
@@ -4,7 +4,7 @@ trait AnySyntax {
   implicit final def anySyntaxMouse[A](oa: A): AnyOps[A] = new AnyOps(oa)
 }
 
-final class AnyOps[A](val oa: A) extends AnyVal {
+final class AnyOps[A](private val oa: A) extends AnyVal {
   @inline def |>[B] (f: A => B) = f(oa)
   @inline def thrush[B] (f: A => B) = f(oa)
   @inline def <|(f: A => Unit): A = {

--- a/shared/src/main/scala/mouse/anyf.scala
+++ b/shared/src/main/scala/mouse/anyf.scala
@@ -5,7 +5,7 @@ trait AnyFSyntax {
   implicit final def anyfSyntaxMouse[F[_], A](fa: F[A]): AnyFOps[F, A] = new AnyFOps(fa)
 }
 
-final class AnyFOps[F[_], A](val fa: F[A]) extends AnyVal {
+final class AnyFOps[F[_], A](private val fa: F[A]) extends AnyVal {
   @inline def ||>[G[_]](f: F ~> G): G[A] = f(fa)
   @inline def thrushK[G[_]](f: F ~> G): G[A] = f(fa)
 }

--- a/shared/src/main/scala/mouse/boolean.scala
+++ b/shared/src/main/scala/mouse/boolean.scala
@@ -6,7 +6,7 @@ trait BooleanSyntax {
   implicit final def booleanSyntaxMouse(b: Boolean): BooleanOps = new BooleanOps(b)
 }
 
-final class BooleanOps(val b: Boolean) extends AnyVal {
+final class BooleanOps(private val b: Boolean) extends AnyVal {
 
   @inline def option[A](a: => A): Option[A] = fold(Some(a), None)
 

--- a/shared/src/main/scala/mouse/double.scala
+++ b/shared/src/main/scala/mouse/double.scala
@@ -5,7 +5,7 @@ trait DoubleSyntax {
   implicit final def doubleSyntaxMouse(n: Double): DoubleOps = new DoubleOps(n)
 }
 
-final class DoubleOps(val n: Double) extends AnyVal {
+final class DoubleOps(private val n: Double) extends AnyVal {
 
   @inline def toByteArray: Array[Byte] = java.nio.ByteBuffer.allocate(8).putDouble(n).array()
 

--- a/shared/src/main/scala/mouse/int.scala
+++ b/shared/src/main/scala/mouse/int.scala
@@ -5,7 +5,7 @@ trait IntSyntax {
   implicit final def intSyntaxMouse(n: Int): IntOps = new IntOps(n)
 }
 
-final class IntOps(val n: Int) extends AnyVal {
+final class IntOps(private val n: Int) extends AnyVal {
 
   @inline def toByteArray: Array[Byte] = java.nio.ByteBuffer.allocate(4).putInt(n).array()
 

--- a/shared/src/main/scala/mouse/long.scala
+++ b/shared/src/main/scala/mouse/long.scala
@@ -5,7 +5,7 @@ trait LongSyntax {
   implicit final def longSyntaxMouse(n: Long): LongOps = new LongOps(n)
 }
 
-final class LongOps(val n: Long) extends AnyVal {
+final class LongOps(private val n: Long) extends AnyVal {
 
   @inline def toByteArray: Array[Byte] = java.nio.ByteBuffer.allocate(8).putLong(n).array()
 

--- a/shared/src/main/scala/mouse/option.scala
+++ b/shared/src/main/scala/mouse/option.scala
@@ -6,7 +6,7 @@ trait OptionSyntax {
   implicit final def optionSyntaxMouse[A](oa: Option[A]): OptionOps[A] = new OptionOps(oa)
 }
 
-final class OptionOps[A](val oa: Option[A]) extends AnyVal {
+final class OptionOps[A](private val oa: Option[A]) extends AnyVal {
 
   @inline def cata[B](some: A => B, none: => B): B = oa.fold[B](none)(some)
 

--- a/shared/src/main/scala/mouse/partialFunction.scala
+++ b/shared/src/main/scala/mouse/partialFunction.scala
@@ -8,7 +8,7 @@ trait PartialFunctionLift {
 object PartialFunctionLift {
 
   //https://typelevel.org/cats/guidelines.html#partially-applied-type-params
-  private[mouse] final class LiftEitherPartiallyApplied[A](val dummy: Boolean = true ) extends AnyVal {
+  private[mouse] final class LiftEitherPartiallyApplied[A](private val dummy: Boolean = true ) extends AnyVal {
     def apply[B, C](pf: PartialFunction[A, B], orElse: A => C): A => Either[C, B] =
       (a: A) => pf.lift(a).toRight(orElse(a))
   }

--- a/shared/src/main/scala/mouse/string.scala
+++ b/shared/src/main/scala/mouse/string.scala
@@ -7,7 +7,7 @@ trait StringSyntax {
   implicit def stringSyntaxMouse(s: String): StringOps = new StringOps(s)
 }
 
-final class StringOps(val s: String) extends AnyVal {
+final class StringOps(private val s: String) extends AnyVal {
 
   @inline def parseBoolean: IllegalArgumentException Either Boolean = Either.catchOnly[IllegalArgumentException](s.toBoolean)
 

--- a/shared/src/main/scala/mouse/try.scala
+++ b/shared/src/main/scala/mouse/try.scala
@@ -9,7 +9,7 @@ trait TrySyntax {
   @inline implicit final def trySyntaxMouse[A](ta: Try[A]): TryOps[A] = new TryOps(ta)
 }
 
-final class TryOps[A](val ta: Try[A]) extends AnyVal {
+final class TryOps[A](private val ta: Try[A]) extends AnyVal {
 
   @inline def cata[B](success: A => B, failure: Throwable => B): B = ta match {
     case Success(value) => success(value)

--- a/shared/src/test/scala/mouse/StringSyntaxTests.scala
+++ b/shared/src/test/scala/mouse/StringSyntaxTests.scala
@@ -140,7 +140,7 @@ class StringSyntaxTests extends MouseSuite {
 
 }
 
-final class EitherIdOps[A](val obj: A) extends AnyVal {
+final class EitherIdOps[A](private val obj: A) extends AnyVal {
   /** Wrap a value in `Left`. */
   def asLeft[B]: Either[A, B] = Left(obj)
 


### PR DESCRIPTION
if the value is not marked as private, one can access it when the syntax is in place.