### PR TITLE
Use openjdk8 on Travis CI instead of oraclejdk8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ scala:
    - 2.13.0
 
 jdk:
- - oraclejdk8
+ - openjdk8
 
 matrix:
   include:


### PR DESCRIPTION
It looks like Travis have removed their `oraclejdk8` JDK from the default distribution (see [this issue](https://travis-ci.community/t/install-of-oracle-jdk-8-failing/3038/9)). This is causing build failures ([example](https://travis-ci.org/typelevel/mouse/jobs/575150115)).

I've tried to fix this by using `openjdk8` instead of `oraclejdk8`. Manually specifying the distribution with `dist: trusty` may also work, but I don't see any reason to prefer the Oracle JDK to OpenJDK.