### PR TITLE
Add a valueOrPure method to boolean.

### DIFF
--- a/shared/src/main/scala/mouse/boolean.scala
+++ b/shared/src/main/scala/mouse/boolean.scala
@@ -1,6 +1,6 @@
 package mouse
 
-import cats.Monoid
+import cats.{ Applicative, Monoid }
 
 trait BooleanSyntax {
   implicit final def booleanSyntaxMouse(b: Boolean): BooleanOps = new BooleanOps(b)
@@ -24,4 +24,6 @@ final class BooleanOps(val b: Boolean) extends AnyVal {
   @inline def ??[A](a: => A)(implicit M: Monoid[A]): A = valueOrZero(a)
 
   @inline def !?[A](a: => A)(implicit M: Monoid[A]): A = zeroOrValue(a)
+
+  @inline def valueOrPure[F[_], A](fa: =>F[A])(a: =>A)(implicit F: Applicative[F]) = if (b) fa else F.pure(a)
 }

--- a/shared/src/test/scala/mouse/BooleanSyntaxTest.scala
+++ b/shared/src/test/scala/mouse/BooleanSyntaxTest.scala
@@ -32,4 +32,7 @@ class BooleanSyntaxTest extends MouseSuite {
 
   true.!?("Yellow") shouldEqual ""
 
+  true.valueOrPure(Option(1))(2) shouldEqual Some(1)
+
+  false.valueOrPure(Option(1))(2) shouldEqual Some(2)
 }


### PR DESCRIPTION
This is useful for the common (for me at least) situation where based
on the value of a boolean you want to either run another effect or
just return a pure value.

Not at all attached to the name, in fact I think it's a bit confusing
because it's not clear that 'value' means something wrapped in an
Applicatve.