### PR TITLE
add applyIf helper function to BooleanOps

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ import mouse.all._
 scala> true.option("Its true!")
 res0: Option[String] = Some(Its true!)
 
+scala> def makeEven(i: Int) = (i % 2 == 1).applyIf(i)(_ - 1)
+def makeEven(i: Int): Int
+
 scala> res0.cata(msg => s"Message received: ${msg}", "No message")
 res1: String = Message received: Its true!
 

--- a/shared/src/main/scala/mouse/boolean.scala
+++ b/shared/src/main/scala/mouse/boolean.scala
@@ -6,6 +6,10 @@ trait BooleanSyntax {
   implicit final def booleanSyntaxMouse(b: Boolean): BooleanOps = new BooleanOps(b)
 }
 
+class ApplyIfPartiallyApplied[A](a: A) {
+  @inline def apply[B >: A](f: B => B): B = if (b) f(a) else a
+}
+
 final class BooleanOps(private val b: Boolean) extends AnyVal {
 
   @inline def option[A](a: => A): Option[A] = fold(Some(a), None)
@@ -27,8 +31,5 @@ final class BooleanOps(private val b: Boolean) extends AnyVal {
 
   @inline def valueOrPure[F[_], A](fa: =>F[A])(a: =>A)(implicit F: Applicative[F]) = if (b) fa else F.pure(a)
   
-  class ApplyIfPartiallyApplied[A](a: A) {
-    @inline def apply[B >: A](f: B => B): B = if (b) f(a) else a
-  }
-  @inline def applyIf[A](a:A): ApplyIfPartiallyApplied[A] = new ApplyIfPartiallyApplied[A](a)
+  @inline def applyIf[A](a: A): ApplyIfPartiallyApplied[A] = new ApplyIfPartiallyApplied[A](a)
 }

--- a/shared/src/main/scala/mouse/boolean.scala
+++ b/shared/src/main/scala/mouse/boolean.scala
@@ -26,4 +26,6 @@ final class BooleanOps(private val b: Boolean) extends AnyVal {
   @inline def !?[A](a: => A)(implicit M: Monoid[A]): A = zeroOrValue(a)
 
   @inline def valueOrPure[F[_], A](fa: =>F[A])(a: =>A)(implicit F: Applicative[F]) = if (b) fa else F.pure(a)
+  
+  @inline def applyIf[A, B](a: A)(f: A => A): A = if (b) f(a) else a
 }

--- a/shared/src/main/scala/mouse/boolean.scala
+++ b/shared/src/main/scala/mouse/boolean.scala
@@ -27,5 +27,8 @@ final class BooleanOps(private val b: Boolean) extends AnyVal {
 
   @inline def valueOrPure[F[_], A](fa: =>F[A])(a: =>A)(implicit F: Applicative[F]) = if (b) fa else F.pure(a)
   
-  @inline def applyIf[A, B](a: A)(f: A => A): A = if (b) f(a) else a
+  class ApplyIfPartiallyApplied[A](a: A) {
+    @inline def apply[B >: A](f: B => B): B = if (b) f(a) else a
+  }
+  @inline def applyIf[A](a:A): ApplyIfPartiallyApplied[A] = new ApplyIfPartiallyApplied[A](a)
 }

--- a/shared/src/main/scala/mouse/boolean.scala
+++ b/shared/src/main/scala/mouse/boolean.scala
@@ -6,7 +6,7 @@ trait BooleanSyntax {
   implicit final def booleanSyntaxMouse(b: Boolean): BooleanOps = new BooleanOps(b)
 }
 
-class ApplyIfPartiallyApplied[A](a: A) {
+class ApplyIfPartiallyApplied[A](b: Boolean, a: A) {
   @inline def apply[B >: A](f: B => B): B = if (b) f(a) else a
 }
 
@@ -31,5 +31,5 @@ final class BooleanOps(private val b: Boolean) extends AnyVal {
 
   @inline def valueOrPure[F[_], A](fa: =>F[A])(a: =>A)(implicit F: Applicative[F]) = if (b) fa else F.pure(a)
   
-  @inline def applyIf[A](a: A): ApplyIfPartiallyApplied[A] = new ApplyIfPartiallyApplied[A](a)
+  @inline def applyIf[A](a: A): ApplyIfPartiallyApplied[A] = new ApplyIfPartiallyApplied[A](b, a)
 }

--- a/shared/src/test/scala/mouse/BooleanSyntaxTest.scala
+++ b/shared/src/test/scala/mouse/BooleanSyntaxTest.scala
@@ -35,4 +35,10 @@ class BooleanSyntaxTest extends MouseSuite {
   true.valueOrPure(Option(1))(2) shouldEqual Some(1)
 
   false.valueOrPure(Option(1))(2) shouldEqual Some(2)
+  
+  def mutilate(x: CharSequence): CharSequence = x.subSequence(1, 2)
+  true.applyIf("foo")(mutilate) shouldEqual "o"
+  false.applyIf("foo")(mutilate) shouldEqual "foo"
+  
+  true.applyIf(5)(_ - 1)
 }

--- a/shared/src/test/scala/mouse/BooleanSyntaxTest.scala
+++ b/shared/src/test/scala/mouse/BooleanSyntaxTest.scala
@@ -39,6 +39,4 @@ class BooleanSyntaxTest extends MouseSuite {
   def mutilate(x: CharSequence): CharSequence = x.subSequence(1, 2)
   true.applyIf("foo")(mutilate) shouldEqual "o"
   false.applyIf("foo")(mutilate) shouldEqual "foo"
-  
-  true.applyIf(5)(_ - 1)
 }


### PR DESCRIPTION
Just added a one-line helper function to BooleanOps that will apply a function to a value if the boolean is true and return the value unchanged if it's false. I feel I've needed this thing often enough that I'd like to have it in a library.

This pull request contains the obvious implementation: `def applyIf[A, B](a: A)(f: A => A): A = if (b) f(a) else a` . But it doesn't infer the type correctly for something like this:

```scala
def mutilate(x: CharSequence): CharSequence = x.subSequence(3, 5)
true.applyIf("foo")(mutilate)
```
Hence an implementation like this might be more desirable:
```scala
class ApplyIfPartiallyApplied[A](a: A) {
  @inline def apply[B >: A](f: B => B): B = if (b) f(a) else a
}

@inline def applyIf[A](a:A) = new ApplyIfPartiallyApplied[A](a)
```

But otoh, the latter will generate more class file bloat, and I don't know if it'll inline properly. Let me know which one you prefer. 