### PR TITLE
add methods for creating generic errors from string

### DIFF
--- a/shared/src/main/scala/mouse/string.scala
+++ b/shared/src/main/scala/mouse/string.scala
@@ -65,4 +65,18 @@ final class StringOps(private val s: String) extends AnyVal {
 
   private def parse[A](f: String => A): NumberFormatException Either A = Either.catchOnly[NumberFormatException](f(s))
 
+  /**
+   * Wraps a `String` in `Throwable`.
+   */
+  @inline def asThrowable: Throwable = new Throwable(s)
+
+  /**
+   * Wraps a `String` in `Error`.
+   */
+  @inline def asError: Error = new Error(s)
+
+  /**
+   * Wraps a `String` in `Exception`.
+   */
+  @inline def asException: Exception = new Exception(s)
 }

--- a/shared/src/test/scala/mouse/StringSyntaxTests.scala
+++ b/shared/src/test/scala/mouse/StringSyntaxTests.scala
@@ -173,6 +173,14 @@ class StringSyntaxTests extends MouseSuite {
     }
   }
 
+  test("asThrowable, asError and asException") {
+    forAll { s: String =>
+      s.asThrowable.toString should ===(new Throwable(s).toString)
+      s.asError.toString should ===(new Error(s).toString)
+      s.asException.toString should ===(new Exception(s).toString)
+    }
+  }
+
 }
 
 final class EitherIdOps[A](val obj: A) extends AnyVal {


### PR DESCRIPTION
(This PR has been moved from https://github.com/typelevel/cats/pull/3938)

Getting quick-and-dirty errors from string error messages is a pretty common use case. This PR is similar to `asLeft`/`asRight` and `some`/`none` but not widened for `Error`/`Exception` subtypes as they are not ADTs.

Instead of writing this:
```scala
val leftError = Left(new Error("error"))
val ioThrow = new Throwable("error").raiseError[IO, Unit]
```
this PR lets you do this:
```scala
val leftError = "error".asError.asLeft
val ioThrow = "error".asThrowable.raiseError[IO, Unit]
```
Saves you from writing the `new` keyword and parentheses.