### PR TITLE
Add syntax for `F[Option[A]]`

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Mouse includes enrichments for:
 - [Long](./shared/src/main/scala/mouse/long.scala)
 - [Double](./shared/src/main/scala/mouse/double.scala)
 - [Map](./shared/src/main/scala/mouse/map.scala)
+- [F\[Option\[A\]\]](./shared/src/main/scala/mouse/foption.scala)
 
 #### Example:
 
@@ -97,6 +98,9 @@ res0: Either[String,Int] = Right(6)
 
 scala> val mapped = Map(1 -> 2, 3 -> 4).mapKeys(_ * 2)
 mapped: Map[Int,Int] = Map(2 -> 2, 6 -> 4)
+
+scala> val foption = List(Option(1), Option(2), Option(4)).mapIn(_ * 2)
+foption: List[Option[Int]] = List(Some(2), Some(4), Some(8))
 ```
 
 #### Release Notes

--- a/shared/src/main/scala/mouse/all.scala
+++ b/shared/src/main/scala/mouse/all.scala
@@ -12,3 +12,4 @@ trait AllSharedSyntax
     with DoubleSyntax
     with PartialFunctionLift
     with MapSyntax
+    with FOptionSyntax

--- a/shared/src/main/scala/mouse/foption.scala
+++ b/shared/src/main/scala/mouse/foption.scala
@@ -19,7 +19,7 @@ final class FOptionOps[F[_], A](private val foa: F[Option[A]]) extends AnyVal {
 
   def existsF(f: A => F[Boolean])(implicit F: Monad[F]): F[Boolean] =
     F.flatMap(foa) {
-      case None => F.pure(false)
+      case None    => F.pure(false)
       case Some(a) => f(a)
     }
 
@@ -40,7 +40,7 @@ final class FOptionOps[F[_], A](private val foa: F[Option[A]]) extends AnyVal {
 
   def forallF(f: A => F[Boolean])(implicit F: Monad[F]): F[Boolean] =
     F.flatMap(foa) {
-      case None => F.pure(true)
+      case None    => F.pure(true)
       case Some(a) => f(a)
     }
 
@@ -56,7 +56,7 @@ final class FOptionOps[F[_], A](private val foa: F[Option[A]]) extends AnyVal {
   def orElseIn(default: Option[A])(implicit F: Functor[F]): F[Option[A]] =
     F.map(foa) {
       case None => default
-      case x => x
+      case x    => x
     }
 
   def orElseF(defaultF: => F[Option[A]])(implicit F: Monad[F]): F[Option[A]] =

--- a/shared/src/main/scala/mouse/foption.scala
+++ b/shared/src/main/scala/mouse/foption.scala
@@ -1,0 +1,67 @@
+package mouse
+
+import cats.{FlatMap, Functor, Monad}
+
+trait FOptionSyntax {
+  implicit final def FOptionSyntaxMouse[F[_], A](foa: F[Option[A]]): FOptionOps[F, A] = new FOptionOps(foa)
+}
+
+final class FOptionOps[F[_], A](private val foa: F[Option[A]]) extends AnyVal {
+
+  def cata[B](default: => B, f: A => B)(implicit F: Functor[F]): F[B] =
+    F.map(foa)(_.fold(default)(f))
+
+  def cataF[B](default: => F[B], f: A => F[B])(implicit F: FlatMap[F]): F[B] =
+    F.flatMap(foa)(_.fold(default)(f))
+
+  def exists(f: A => Boolean)(implicit F: Functor[F]): F[Boolean] =
+    F.map(foa)(_.exists(f))
+
+  def existsF(f: A => F[Boolean])(implicit F: Monad[F]): F[Boolean] =
+    F.flatMap(foa) {
+      case None => F.pure(false)
+      case Some(a) => f(a)
+    }
+
+  def flatMapIn[B](f: A => Option[B])(implicit F: Functor[F]): F[Option[B]] =
+    F.map(foa)(_.flatMap(f))
+
+  def flatMapF[B](f: A => F[Option[B]])(implicit F: Monad[F]): F[Option[B]] =
+    F.flatMap(foa)(_.fold(F.pure(Option.empty[B]))(f))
+
+  def fold[B](default: => B)(f: A => B)(implicit F: Functor[F]): F[B] =
+    cata(default, f)
+
+  def foldF[B](default: => F[B])(f: A => F[B])(implicit F: FlatMap[F]): F[B] =
+    cataF(default, f)
+
+  def forall(f: A => Boolean)(implicit F: Functor[F]): F[Boolean] =
+    F.map(foa)(_.forall(f))
+
+  def forallF(f: A => F[Boolean])(implicit F: Monad[F]): F[Boolean] =
+    F.flatMap(foa) {
+      case None => F.pure(true)
+      case Some(a) => f(a)
+    }
+
+  def getOrElse[B >: A](a: => B)(implicit F: Functor[F]): F[B] =
+    F.map(foa)(_.fold(a)(identity))
+
+  def getOrElseF[B >: A](fa: => F[B])(implicit F: Monad[F]): F[B] =
+    F.flatMap(foa)(_.fold(fa)(F.pure))
+
+  def mapIn[B](f: A => B)(implicit F: Functor[F]): F[Option[B]] =
+    F.map(foa)(_.map(f))
+
+  def orElse(default: Option[A])(implicit F: Functor[F]): F[Option[A]] =
+    F.map(foa) {
+      case None => default
+      case x => x
+    }
+
+  def orElseF(defaultF: => F[Option[A]])(implicit F: Monad[F]): F[Option[A]] =
+    F.flatMap(foa) {
+      case None => defaultF
+      case x    => F.pure(x)
+    }
+}

--- a/shared/src/main/scala/mouse/foption.scala
+++ b/shared/src/main/scala/mouse/foption.scala
@@ -14,7 +14,7 @@ final class FOptionOps[F[_], A](private val foa: F[Option[A]]) extends AnyVal {
   def cataF[B](default: => F[B], f: A => F[B])(implicit F: FlatMap[F]): F[B] =
     F.flatMap(foa)(_.fold(default)(f))
 
-  def exists(f: A => Boolean)(implicit F: Functor[F]): F[Boolean] =
+  def existsIn(f: A => Boolean)(implicit F: Functor[F]): F[Boolean] =
     F.map(foa)(_.exists(f))
 
   def existsF(f: A => F[Boolean])(implicit F: Monad[F]): F[Boolean] =
@@ -29,13 +29,13 @@ final class FOptionOps[F[_], A](private val foa: F[Option[A]]) extends AnyVal {
   def flatMapF[B](f: A => F[Option[B]])(implicit F: Monad[F]): F[Option[B]] =
     F.flatMap(foa)(_.fold(F.pure(Option.empty[B]))(f))
 
-  def fold[B](default: => B)(f: A => B)(implicit F: Functor[F]): F[B] =
+  def foldIn[B](default: => B)(f: A => B)(implicit F: Functor[F]): F[B] =
     cata(default, f)
 
   def foldF[B](default: => F[B])(f: A => F[B])(implicit F: FlatMap[F]): F[B] =
     cataF(default, f)
 
-  def forall(f: A => Boolean)(implicit F: Functor[F]): F[Boolean] =
+  def forallIn(f: A => Boolean)(implicit F: Functor[F]): F[Boolean] =
     F.map(foa)(_.forall(f))
 
   def forallF(f: A => F[Boolean])(implicit F: Monad[F]): F[Boolean] =
@@ -53,7 +53,7 @@ final class FOptionOps[F[_], A](private val foa: F[Option[A]]) extends AnyVal {
   def mapIn[B](f: A => B)(implicit F: Functor[F]): F[Option[B]] =
     F.map(foa)(_.map(f))
 
-  def orElse(default: Option[A])(implicit F: Functor[F]): F[Option[A]] =
+  def orElseIn(default: Option[A])(implicit F: Functor[F]): F[Option[A]] =
     F.map(foa) {
       case None => default
       case x => x

--- a/shared/src/test/scala/mouse/FOptionSyntaxTest.scala
+++ b/shared/src/test/scala/mouse/FOptionSyntaxTest.scala
@@ -1,0 +1,82 @@
+package mouse
+
+class FOptionSyntaxTest extends MouseSuite {
+  test("FOptionSyntax.cata") {
+    assertEquals(List(Option(1)).cata(0, _ => 2), List(2))
+    assertEquals(List(Option.empty[Int]).cata(0, _ => 2), List(0))
+  }
+
+  test("FOptionSyntax.cataF") {
+    assertEquals(List(Option(1)).cataF(List.empty[Int], _ => List(2)), List(2))
+    assertEquals(List(Option.empty[Int]).cataF(List.empty[Int], _ => List(2)), List.empty[Int])
+  }
+
+  test("FOptionSyntax.existsIn") {
+    assertEquals(Option(Option(1)).existsIn(_ > 2), Option(false))
+    assertEquals(Option(Option(1)).existsIn(_ == 1), Option(true))
+    assertEquals(Option(Option.empty[Int]).existsIn(_ > 2), Option(false))
+  }
+
+  test("FOptionSyntax.existsF") {
+    assertEquals(Option(Option(1)).existsF(a => Option(a > 2)), Option(false))
+    assertEquals(Option(Option(1)).existsF(a => Option(a == 1)), Option(true))
+    assertEquals(Option(Option.empty[Int]).existsF(a => Option(a > 2)), Option(false))
+  }
+
+  test("FOptionSyntax.flatMapIn") {
+    assertEquals(List(Option(1)).flatMapIn(a => Option(a * 2)), List(Option(2)))
+    assertEquals(List(Option.empty[Int]).flatMapIn(a => Option(a * 2)), List(Option.empty[Int]))
+  }
+
+  test("FOptionSyntax.flatMapF") {
+    assertEquals(List(Option(1)).flatMapF(a => List(Option(a * 2))), List(Option(2)))
+    assertEquals(List(Option.empty[Int]).flatMapF(a => List(Option(a * 2))), List(Option.empty[Int]))
+  }
+
+  test("FOptionSyntax.foldIn") {
+    assertEquals(List(Option(1)).foldIn(false)(_ => true), List(true))
+    assertEquals(List(Option.empty[Int]).foldIn(false)(_ => true), List(false))
+  }
+
+  test("FOptionSyntax.foldF") {
+    assertEquals(List(Option(1)).foldF(List(false))(_ => List(true)), List(true))
+    assertEquals(List(Option.empty[Int]).foldF(List(false))(_ => List(true)), List(false))
+  }
+
+  test("FOptionSyntax.forallIn") {
+    assertEquals(Option(Option(1)).forallIn(_ > 2), Option(false))
+    assertEquals(Option(Option(1)).forallIn(_ == 1), Option(true))
+    assertEquals(Option(Option.empty[Int]).forallIn(_ > 2), Option(true))
+  }
+
+  test("FOptionSyntax.forallF") {
+    assertEquals(Option(Option(1)).forallF(a => Option(a > 2)), Option(false))
+    assertEquals(Option(Option(1)).forallF(a => Option(a == 1)), Option(true))
+    assertEquals(Option(Option.empty[Int]).forallF(a => Option(a > 2)), Option(true))
+  }
+
+  test("FOptionSyntax.getOrElse") {
+    assertEquals(List(Option(1)).getOrElse(0), List(1))
+    assertEquals(List(Option.empty[Int]).getOrElse(0), List(0))
+  }
+
+  test("FOptionSyntax.getOrElseF") {
+    assertEquals(List(Option(1)).getOrElseF(List(0)), List(1))
+    assertEquals(List(Option.empty[Int]).getOrElseF(List(0)), List(0))
+  }
+
+  test("FOptionSyntax.mapIn") {
+    assertEquals(List(Option(1)).mapIn(_ + 1), List(Option(2)))
+    assertEquals(List(Option.empty[Int]).mapIn(_ + 1), List(Option.empty[Int]))
+  }
+
+  test("FOptionSyntax.orElseIn") {
+    assertEquals(List(Option(1)).orElseIn(Option(0)), List(Option(1)))
+    assertEquals(List(Option.empty[Int]).orElseIn(Option(0)), List(Option(0)))
+  }
+
+  test("FOptionSyntax.orElseF") {
+    assertEquals(List(Option(1)).orElseF(List(Option(0))), List(Option(1)))
+    assertEquals(List(Option.empty[Int]).orElseF(List(Option(0))), List(Option(0)))
+  }
+}


### PR DESCRIPTION
This adds syntax for `F[Option[A]]`. Sometimes using `OptionT` is not applicable (or `F[Option[A]]` just more preferred). For these cases that syntax would be useful.