### PR TITLE
Specify dialect for `Scalafmt`

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -9,3 +9,4 @@ rewrite.rules = [AvoidInfix, SortImports, RedundantParens, SortModifiers]
 newlines.afterCurlyLambda = preserve
 docstrings.style = Asterisk
 docstrings.oneline = unfold
+runner.dialect = "scala213source3"


### PR DESCRIPTION
Within the current version of the `Scalafmt` dialect should be specified explicitly. Otherwise used deprecated default. And warning `Default dialect is deprecated; use explicit: [Scala211,scala212,Scala212Source3,scala213,Scala213Source3,Sbt0137,Sbt1,scala3]` is produced on every fmt command.