### PR TITLE
add option syntax - whenExistsA

### DIFF
--- a/shared/src/main/scala/mouse/option.scala
+++ b/shared/src/main/scala/mouse/option.scala
@@ -1,5 +1,7 @@
 package mouse
 
+import cats.Applicative
+
 import scala.util.{Failure, Success, Try}
 
 trait OptionSyntax {
@@ -13,6 +15,8 @@ final class OptionOps[A](private val oa: Option[A]) extends AnyVal {
   @inline def toTry(ex: => Throwable): Try[A] = cata(Success(_), Failure(ex))
 
   @inline def toTryMsg(msg: => String): Try[A] = toTry(new RuntimeException(msg))
+
+  @inline def whenExistsA[F[_]: Applicative](f: A => F[Unit]): F[Unit] = cata(f, Applicative[F].unit)
 
   /**
    * Same as oa.toRight except that it fixes the type to Either[B, A] On Scala prior to 2.12, toRight returns

--- a/shared/src/test/scala/mouse/OptionSyntaxTest.scala
+++ b/shared/src/test/scala/mouse/OptionSyntaxTest.scala
@@ -1,5 +1,7 @@
 package mouse
 
+import cats.Id
+
 import scala.util.{Failure, Success}
 
 class OptionSyntaxTest extends MouseSuite {
@@ -29,5 +31,16 @@ class OptionSyntaxTest extends MouseSuite {
     assertEquals(Option(3).left("S"), Option(3).toLeft("S"))
     assertEquals(None.left("S"), None.toLeft("S"))
     Option(3).left("S").shouldBeA[Either[Int, String]]
+  }
+
+  test("OptionSyntax.whenExistsA") {
+    var a = 1
+    var b = 1
+    val f: Int => Id[Unit] = i => a = i
+    val g: Int => Id[Unit] = i => b = i
+    Option(2).whenExistsA(f).shouldBeA[Id[Unit]]
+    Option.empty[Int].whenExistsA(g)
+    assertEquals(a, 2)
+    assertEquals(b, 1)
   }
 }


### PR DESCRIPTION
Just a quick syntax addition that I have found useful in the past. 

Performs a unit effect using a value if it exists, otherwise does nothing. 