### PR TITLE
Add syntax for `F[Either[A, B]]`

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Mouse includes enrichments for:
 - [Double](./shared/src/main/scala/mouse/double.scala)
 - [Map](./shared/src/main/scala/mouse/map.scala)
 - [F\[Option\[A\]\]](./shared/src/main/scala/mouse/foption.scala)
+- [F\[Either\[A, B\]\]](./shared/src/main/scala/mouse/feither.scala)
 
 #### Example:
 
@@ -101,6 +102,9 @@ mapped: Map[Int,Int] = Map(2 -> 2, 6 -> 4)
 
 scala> val foption = List(Option(1), Option(2), Option(4)).mapIn(_ * 2)
 foption: List[Option[Int]] = List(Some(2), Some(4), Some(8))
+
+scala> val feither = List(Either.cond(true, 1, "0")).mapIn(_ * 2)
+foption: List[Either[String, Int]] = List(Right(2))
 ```
 
 #### Release Notes

--- a/shared/src/main/scala/mouse/all.scala
+++ b/shared/src/main/scala/mouse/all.scala
@@ -13,3 +13,4 @@ trait AllSharedSyntax
     with PartialFunctionLift
     with MapSyntax
     with FOptionSyntax
+    with FEitherSyntax

--- a/shared/src/main/scala/mouse/feither.scala
+++ b/shared/src/main/scala/mouse/feither.scala
@@ -1,0 +1,65 @@
+package mouse
+
+import cats.{Applicative, FlatMap, Functor, Monad, Traverse}
+import cats.instances.either._
+
+trait FEitherSyntax {
+  implicit final def FEitherSyntaxMouse[F[_], L, R](felr: F[Either[L, R]]): FEitherOps[F, L, R] =
+    new FEitherOps(felr)
+}
+
+final class FEitherOps[F[_], L, R](private val felr: F[Either[L, R]]) extends AnyVal {
+  def cata[A](left: L => A, right: R => A)(implicit F: Functor[F]): F[A] =
+    F.map(felr)(_.fold(left, right))
+
+  def cataF[A](left: L => F[A], right: R => F[A])(implicit F: FlatMap[F]): F[A] =
+    F.flatMap(felr)(_.fold(left, right))
+
+  def flatMapIn[A >: L, B](f: R => Either[A, B])(implicit F: Functor[F]): F[Either[A, B]] =
+    F.map(felr)(_.flatMap(f))
+
+  def foldIn[A](left: L => A)(right: R => A)(implicit F: Functor[F]): F[A] =
+    cata(left, right)
+
+  def foldF[A](left: L => F[A])(right: R => F[A])(implicit F: FlatMap[F]): F[A] =
+    cataF(left, right)
+
+  def getOrElse[A >: R](right: => A)(implicit F: Functor[F]): F[A] =
+    F.map(felr)(_.fold(_ => right, identity))
+
+  def getOrElseF[A >: R](right: => F[A])(implicit F: Monad[F]): F[A] =
+    F.flatMap(felr)(_.fold(_ => right, F.pure))
+
+  def leftTraverseIn[G[_], A](f: L => G[A])(implicit F: Functor[F], G: Applicative[G]): F[G[Either[A, R]]] =
+    F.map(felr) {
+      case Left(left)   => G.map(f(left))(Left(_))
+      case r @ Right(_) => G.pure(r.asInstanceOf[Right[A, R]])
+    }
+
+  def leftTraverseF[G[_], A](f: L => G[A])(implicit F: Traverse[F], G: Applicative[G]): G[F[Either[A, R]]] =
+    F.traverse(felr) {
+      case Left(left)   => G.map(f(left))(Left(_))
+      case r @ Right(_) => G.pure(r.asInstanceOf[Right[A, R]])
+    }
+
+  def mapIn[A](f: R => A)(implicit F: Functor[F]): F[Either[L, A]] =
+    F.map(felr)(_.map(f))
+
+  def orElseIn[A >: L, B >: R](f: => Either[A, B])(implicit F: Functor[F]): F[Either[A, B]] =
+    F.map(felr) {
+      case r: Right[L, R] => r: Either[A, B]
+      case _              => f
+    }
+
+  def orElseF[A >: L, B >: R](f: => F[Either[A, B]])(implicit F: Monad[F]): F[Either[A, B]] =
+    F.flatMap(felr) {
+      case r: Right[L, R] => F.pure[Either[A, B]](r)
+      case _              => f
+    }
+
+  def traverseIn[G[_]: Applicative, A](f: R => G[A])(implicit F: Functor[F]): F[G[Either[L, A]]] =
+    F.map(felr)(elr => catsStdInstancesForEither[L].traverse(elr)(f))
+
+  def traverseF[G[_]: Applicative, A](f: R => G[A])(implicit F: Traverse[F]): G[F[Either[L, A]]] =
+    F.traverse(felr)(elr => catsStdInstancesForEither[L].traverse(elr)(f))
+}

--- a/shared/src/main/scala/mouse/feither.scala
+++ b/shared/src/main/scala/mouse/feither.scala
@@ -30,7 +30,7 @@ final class FEitherOps[F[_], L, R](private val felr: F[Either[L, R]]) extends An
   def foldF[A](left: L => F[A])(right: R => F[A])(implicit F: FlatMap[F]): F[A] =
     cataF(left, right)
 
-  def getOrElse[A >: R](right: => A)(implicit F: Functor[F]): F[A] =
+  def getOrElseIn[A >: R](right: => A)(implicit F: Functor[F]): F[A] =
     F.map(felr)(_.fold(_ => right, identity))
 
   def getOrElseF[A >: R](right: => F[A])(implicit F: Monad[F]): F[A] =

--- a/shared/src/test/scala/mouse/FEitherSyntaxTest.scala
+++ b/shared/src/test/scala/mouse/FEitherSyntaxTest.scala
@@ -36,9 +36,9 @@ class FEitherSyntaxTest extends MouseSuite {
     assertEquals(leftValue.foldF(_ => List(0))(_ => List(1)), List(0))
   }
 
-  test("FEitherSyntax.getOrElse") {
-    assertEquals(rightValue.getOrElse(0), List(42))
-    assertEquals(leftValue.getOrElse(0), List(0))
+  test("FEitherSyntax.getOrElseIn") {
+    assertEquals(rightValue.getOrElseIn(0), List(42))
+    assertEquals(leftValue.getOrElseIn(0), List(0))
   }
 
   test("FEitherSyntax.getOrElseF") {

--- a/shared/src/test/scala/mouse/FEitherSyntaxTest.scala
+++ b/shared/src/test/scala/mouse/FEitherSyntaxTest.scala
@@ -1,0 +1,98 @@
+package mouse
+
+import cats.syntax.either._
+
+class FEitherSyntaxTest extends MouseSuite {
+  private val rightValue = List(42.asRight[String])
+  private val leftValue = List("42".asLeft[Int])
+
+  test("FEitherSyntax.cata") {
+    assertEquals(rightValue.cata(_ => 0, _ => 1), List(1))
+    assertEquals(leftValue.cata(_ => 0, _ => 1), List(0))
+  }
+
+  test("FEitherSyntax.cataF") {
+    assertEquals(rightValue.cataF(_ => List(0), _ => List(1)), List(1))
+    assertEquals(leftValue.cataF(_ => List(0), _ => List(1)), List(0))
+  }
+
+  test("FEitherSyntax.flatMapIn") {
+    assertEquals(rightValue.flatMapIn(i => (i * 2).asRight[String]), List(84.asRight[String]))
+    assertEquals(leftValue.flatMapIn(i => (i * 2).asRight[String]), leftValue)
+  }
+
+  test("FEitherSyntax.flatMapF") {
+    assertEquals(rightValue.flatMapF(i => List((i * 2).asRight[String])), List(84.asRight[String]))
+    assertEquals(leftValue.flatMapF(i => List((i * 2).asRight[String])), leftValue)
+  }
+
+  test("FEitherSyntax.foldIn") {
+    assertEquals(rightValue.foldIn(_ => 0)(_ => 1), List(1))
+    assertEquals(leftValue.foldIn(_ => 0)(_ => 1), List(0))
+  }
+
+  test("FEitherSyntax.foldF") {
+    assertEquals(rightValue.foldF(_ => List(0))(_ => List(1)), List(1))
+    assertEquals(leftValue.foldF(_ => List(0))(_ => List(1)), List(0))
+  }
+
+  test("FEitherSyntax.getOrElse") {
+    assertEquals(rightValue.getOrElse(0), List(42))
+    assertEquals(leftValue.getOrElse(0), List(0))
+  }
+
+  test("FEitherSyntax.getOrElseF") {
+    assertEquals(rightValue.getOrElseF(List(0)), List(42))
+    assertEquals(leftValue.getOrElseF(List(0)), List(0))
+  }
+
+  test("FEitherSyntax.leftFlatMapIn") {
+    assertEquals(rightValue.leftFlatMapIn(_ => "".asLeft[Int]), rightValue)
+    assertEquals(leftValue.leftFlatMapIn(_ => "".asLeft[Int]), List("".asLeft[Int]))
+  }
+
+  test("FEitherSyntax.leftFlatMapF") {
+    assertEquals(rightValue.leftFlatMapF(_ => List("".asLeft[Int])), rightValue)
+    assertEquals(leftValue.leftFlatMapF(_ => List("".asLeft[Int])), List("".asLeft[Int]))
+  }
+
+  test("FEitherSyntax.leftMapIn") {
+    assertEquals(rightValue.leftMapIn(_ => ""), rightValue)
+    assertEquals(leftValue.leftMapIn(_ => ""), List("".asLeft[Int]))
+  }
+
+  test("FEitherSyntax.leftTraverseIn") {
+    assertEquals(rightValue.leftTraverseIn(_ => Option("")), List(Option(42.asRight[String])))
+    assertEquals(leftValue.leftTraverseIn(_ => Option("")), List(Option("".asLeft[Int])))
+  }
+
+  test("FEitherSyntax.leftTraverseF") {
+    assertEquals(rightValue.leftTraverseF(_ => Option("")), Option(List(42.asRight[String])))
+    assertEquals(leftValue.leftTraverseF(_ => Option("")), Option(List("".asLeft[Int])))
+  }
+
+  test("FEitherSyntax.mapIn") {
+    assertEquals(rightValue.mapIn(_ * 2), List(84.asRight[String]))
+    assertEquals(leftValue.mapIn(_ * 2), leftValue)
+  }
+
+  test("FEitherSyntax.orElseIn") {
+    assertEquals(rightValue.orElseIn(0.asRight[String]), rightValue)
+    assertEquals(leftValue.orElseIn(0.asRight[String]), List(0.asRight[String]))
+  }
+
+  test("FEitherSyntax.orElseF") {
+    assertEquals(rightValue.orElseF(List(0.asRight[String])), rightValue)
+    assertEquals(leftValue.orElseF(List(0.asRight[String])), List(0.asRight[String]))
+  }
+
+  test("FEitherSyntax.traverseIn") {
+    assertEquals(rightValue.traverseIn(_ => Option(1)), List(Option(1.asRight[String])))
+    assertEquals(leftValue.traverseIn(_ => Option(0)), List(Option("42".asLeft[Int])))
+  }
+
+  test("FEitherSyntax.traverseF") {
+    assertEquals(rightValue.traverseF(_ => Option(1)), Option(List(1.asRight[String])))
+    assertEquals(leftValue.traverseF(_ => Option(0)), Option(List("42".asLeft[Int])))
+  }
+}


### PR DESCRIPTION
This adds syntax for `F[Either[A, B]]`. As well as for `F[Option[A]]`, sometimes using monad transformers is not applicable (or `F[Either[A, B]]` just more preferred).
