### PR TITLE
Convenience functions for lifting to OptionT & EitherT

### DIFF
--- a/shared/src/main/scala/mouse/feither.scala
+++ b/shared/src/main/scala/mouse/feither.scala
@@ -1,5 +1,6 @@
 package mouse
 
+import cats.data.EitherT
 import cats.{Applicative, FlatMap, Functor, Monad, Traverse}
 import cats.instances.either._
 
@@ -86,4 +87,8 @@ final class FEitherOps[F[_], L, R](private val felr: F[Either[L, R]]) extends An
 
   def traverseF[G[_]: Applicative, A](f: R => G[A])(implicit F: Traverse[F]): G[F[Either[L, A]]] =
     F.traverse(felr)(elr => catsStdInstancesForEither[L].traverse(elr)(f))
+
+  def liftEitherT: EitherT[F, L, R] =
+    EitherT(felr)
+
 }

--- a/shared/src/main/scala/mouse/foption.scala
+++ b/shared/src/main/scala/mouse/foption.scala
@@ -1,5 +1,6 @@
 package mouse
 
+import cats.data.OptionT
 import cats.{Applicative, FlatMap, Functor, Monad, Traverse}
 
 trait FOptionSyntax {
@@ -83,4 +84,7 @@ final class FOptionOps[F[_], A](private val foa: F[Option[A]]) extends AnyVal {
 
   def traverseF[G[_]: Applicative, B](f: A => G[B])(implicit F: Traverse[F]): G[F[Option[B]]] =
     F.traverse(foa)(a => Traverse[Option].traverse(a)(f))
+
+  def liftOptionT: OptionT[F, A] =
+    OptionT(foa)
 }

--- a/shared/src/test/scala/mouse/FEitherSyntaxTest.scala
+++ b/shared/src/test/scala/mouse/FEitherSyntaxTest.scala
@@ -1,5 +1,6 @@
 package mouse
 
+import cats.data.EitherT
 import cats.syntax.either._
 
 class FEitherSyntaxTest extends MouseSuite {
@@ -94,5 +95,10 @@ class FEitherSyntaxTest extends MouseSuite {
   test("FEitherSyntax.traverseF") {
     assertEquals(rightValue.traverseF(_ => Option(1)), Option(List(1.asRight[String])))
     assertEquals(leftValue.traverseF(_ => Option(0)), Option(List("42".asLeft[Int])))
+  }
+
+  test("FEitherSyntax.liftEitherT") {
+    assertEquals(rightValue.liftEitherT, EitherT(rightValue))
+    assertEquals(leftValue.liftEitherT, EitherT(leftValue))
   }
 }

--- a/shared/src/test/scala/mouse/FOptionSyntaxTest.scala
+++ b/shared/src/test/scala/mouse/FOptionSyntaxTest.scala
@@ -1,5 +1,7 @@
 package mouse
 
+import cats.data.OptionT
+
 class FOptionSyntaxTest extends MouseSuite {
   test("FOptionSyntax.cata") {
     assertEquals(List(Option(1)).cata(0, _ => 2), List(2))
@@ -102,5 +104,10 @@ class FOptionSyntaxTest extends MouseSuite {
     assertEquals(List(Option(1)).traverseF(a => Option(a * 2)), Option(List(Option(2))))
     assertEquals(List.empty[Option[Int]].traverseF(a => Option(a * 2)), Option(List.empty[Option[Int]]))
     assertEquals(List(Option.empty[Int]).traverseF(a => Option(a * 2)), Option(List(Option.empty[Int])))
+  }
+
+  test("FOptionSyntax.liftOptionT") {
+    assertEquals(List(Option(1)).liftOptionT, OptionT(List(Option(1))))
+    assertEquals(List(Option.empty[Int]).liftOptionT, OptionT(List(Option.empty[Int])))
   }
 }


### PR DESCRIPTION
Adding some extension methods that I often wish I had. It really boils down to code cleanliness preferences.

I just wanted to get some feedback on whether others feel like these conversions belong here, or if they're fundamentally anathema/broken in some non-obvious way.

If others are amenable then I will write some tests and correct the formatting