### PR TITLE
Add `append` and `prepend` operators to the tuple syntax

### DIFF
--- a/shared/src/main/scala-2.x/src/main/scala/mouse/tuple.scala
+++ b/shared/src/main/scala-2.x/src/main/scala/mouse/tuple.scala
@@ -87,115 +87,298 @@ trait TupleSyntax {
 }
 
 final class Tuple2SyntaxOps[A1, A2](private val t: (A1, A2)) extends AnyVal {
+
+  /**
+   * Return a copy of `this` tuple with an element prepended.
+   *
+   * @example
+   *   {{{0 *: (1, 2) // the result is (0, 1, 2)}}}
+   */
   def *:[A0](elem: A0): (A0, A1, A2) = (elem, t._1, t._2)
+
+  /**
+   * Return a copy of `this` tuple with an element appended.
+   *
+   * @example
+   *   {{{(1, 2) :* 3 // the result is (1, 2, 3)}}}
+   */
   def :*[A3](elem: A3): (A1, A2, A3) = (t._1, t._2, elem)
+
   @inline def head: A1 = t._1
+
   @inline def last: A2 = t._2
 }
 
 final class Tuple3SyntaxOps[A1, A2, A3](private val t: (A1, A2, A3)) extends AnyVal {
+
+  /**
+   * Return a copy of `this` tuple with an element prepended.
+   *
+   * @example
+   *   {{{0 *: (1, 2, 3) // the result is (0, 1, 2, 3)}}}
+   */
   def *:[A0](elem: A0): (A0, A1, A2, A3) = (elem, t._1, t._2, t._3)
+
+  /**
+   * Return a copy of `this` tuple with an element appended.
+   *
+   * @example
+   *   {{{(1, 2, 3) :* 4 // the result is (1, 2, 3, 4)}}}
+   */
   def :*[A4](elem: A4): (A1, A2, A3, A4) = (t._1, t._2, t._3, elem)
+
   @inline def head: A1 = t._1
+
   def init: (A1, A2) = (t._1, t._2)
+
   @inline def last: A3 = t._3
+
   def tail: (A2, A3) = (t._2, t._3)
 }
 
 final class Tuple4SyntaxOps[A1, A2, A3, A4](private val t: (A1, A2, A3, A4)) extends AnyVal {
+
+  /**
+   * Return a copy of `this` tuple with an element prepended.
+   *
+   * @example
+   *   {{{0 *: (1, 2, 3, 4) // the result is (0, 1, 2, 3, 4)}}}
+   */
   def *:[A0](elem: A0): (A0, A1, A2, A3, A4) = (elem, t._1, t._2, t._3, t._4)
+
+  /**
+   * Return a copy of `this` tuple with an element appended.
+   *
+   * @example
+   *   {{{(1, 2, 3, 4) :* 5 // the result is (1, 2, 3, 4, 5)}}}
+   */
   def :*[A5](elem: A5): (A1, A2, A3, A4, A5) = (t._1, t._2, t._3, t._4, elem)
+
   @inline def head: A1 = t._1
+
   def init: (A1, A2, A3) = (t._1, t._2, t._3)
+
   @inline def last: A4 = t._4
+
   def tail: (A2, A3, A4) = (t._2, t._3, t._4)
 }
 
 final class Tuple5SyntaxOps[A1, A2, A3, A4, A5](private val t: (A1, A2, A3, A4, A5)) extends AnyVal {
+
+  /**
+   * Return a copy of `this` tuple with an element prepended.
+   *
+   * @example
+   *   {{{0 *: (1, 2, 3, 4, 5) // the result is (0, 1, 2, 3, 4, 5)}}}
+   */
   def *:[A0](elem: A0): (A0, A1, A2, A3, A4, A5) = (elem, t._1, t._2, t._3, t._4, t._5)
+
+  /**
+   * Return a copy of `this` tuple with an element appended.
+   *
+   * @example
+   *   {{{(1, 2, 3, 4, 5) :* 6 // the result is (1, 2, 3, 4, 5, 6)}}}
+   */
   def :*[A6](elem: A6): (A1, A2, A3, A4, A5, A6) = (t._1, t._2, t._3, t._4, t._5, elem)
+
   @inline def head: A1 = t._1
+
   def init: (A1, A2, A3, A4) = (t._1, t._2, t._3, t._4)
+
   @inline def last: A5 = t._5
+
   def tail: (A2, A3, A4, A5) = (t._2, t._3, t._4, t._5)
 }
 
 final class Tuple6SyntaxOps[A1, A2, A3, A4, A5, A6](private val t: (A1, A2, A3, A4, A5, A6)) extends AnyVal {
+
+  /**
+   * Return a copy of `this` tuple with an element prepended.
+   *
+   * @example
+   *   {{{0 *: (1, 2, 3, 4, 5, 6) // the result is (0, 1, 2, 3, 4, 5, 6)}}}
+   */
   def *:[A0](elem: A0): (A0, A1, A2, A3, A4, A5, A6) = (elem, t._1, t._2, t._3, t._4, t._5, t._6)
+
+  /**
+   * Return a copy of `this` tuple with an element appended.
+   *
+   * @example
+   *   {{{(1, 2, 3, 4, 5, 6) :* 7 // the result is (1, 2, 3, 4, 5, 6, 7)}}}
+   */
   def :*[A7](elem: A7): (A1, A2, A3, A4, A5, A6, A7) = (t._1, t._2, t._3, t._4, t._5, t._6, elem)
+
   @inline def head: A1 = t._1
+
   def init: (A1, A2, A3, A4, A5) = (t._1, t._2, t._3, t._4, t._5)
+
   @inline def last: A6 = t._6
+
   def tail: (A2, A3, A4, A5, A6) = (t._2, t._3, t._4, t._5, t._6)
 }
 
 final class Tuple7SyntaxOps[A1, A2, A3, A4, A5, A6, A7](private val t: (A1, A2, A3, A4, A5, A6, A7)) extends AnyVal {
+
+  /**
+   * Return a copy of `this` tuple with an element prepended.
+   *
+   * @example
+   *   {{{0 *: (1, 2, 3, 4, 5, 6, 7) // the result is (0, 1, 2, 3, 4, 5, 6, 7)}}}
+   */
   def *:[A0](elem: A0): (A0, A1, A2, A3, A4, A5, A6, A7) = (elem, t._1, t._2, t._3, t._4, t._5, t._6, t._7)
+
+  /**
+   * Return a copy of `this` tuple with an element appended.
+   *
+   * @example
+   *   {{{(1, 2, 3, 4, 5, 6, 7) :* 8 // the result is (1, 2, 3, 4, 5, 6, 7, 8)}}}
+   */
   def :*[A8](elem: A8): (A1, A2, A3, A4, A5, A6, A7, A8) = (t._1, t._2, t._3, t._4, t._5, t._6, t._7, elem)
+
   @inline def head: A1 = t._1
+
   def init: (A1, A2, A3, A4, A5, A6) = (t._1, t._2, t._3, t._4, t._5, t._6)
+
   @inline def last: A7 = t._7
+
   def tail: (A2, A3, A4, A5, A6, A7) = (t._2, t._3, t._4, t._5, t._6, t._7)
 }
 
 final class Tuple8SyntaxOps[A1, A2, A3, A4, A5, A6, A7, A8](private val t: (A1, A2, A3, A4, A5, A6, A7, A8))
     extends AnyVal {
+
+  /**
+   * Return a copy of `this` tuple with an element prepended.
+   *
+   * @example
+   *   {{{0 *: (1, 2, 3, 4, 5, 6, 7, 8) // the result is (0, 1, 2, 3, 4, 5, 6, 7, 8)}}}
+   */
   def *:[A0](elem: A0): (A0, A1, A2, A3, A4, A5, A6, A7, A8) = (elem, t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8)
+
+  /**
+   * Return a copy of `this` tuple with an element appended.
+   *
+   * @example
+   *   {{{(1, 2, 3, 4, 5, 6, 7, 8) :* 9 // the result is (1, 2, 3, 4, 5, 6, 7, 8, 9)}}}
+   */
   def :*[A9](elem: A9): (A1, A2, A3, A4, A5, A6, A7, A8, A9) = (t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, elem)
+
   @inline def head: A1 = t._1
+
   def init: (A1, A2, A3, A4, A5, A6, A7) = (t._1, t._2, t._3, t._4, t._5, t._6, t._7)
+
   @inline def last: A8 = t._8
+
   def tail: (A2, A3, A4, A5, A6, A7, A8) = (t._2, t._3, t._4, t._5, t._6, t._7, t._8)
 }
 
 final class Tuple9SyntaxOps[A1, A2, A3, A4, A5, A6, A7, A8, A9](private val t: (A1, A2, A3, A4, A5, A6, A7, A8, A9))
     extends AnyVal {
+
+  /**
+   * Return a copy of `this` tuple with an element prepended.
+   *
+   * @example
+   *   {{{0 *: (1, 2, 3, 4, 5, 6, 7, 8, 9) // the result is (0, 1, 2, 3, 4, 5, 6, 7, 8, 9)}}}
+   */
   def *:[A0](elem: A0): (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9) =
     (elem, t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9)
+
+  /**
+   * Return a copy of `this` tuple with an element appended.
+   *
+   * @example
+   *   {{{(1, 2, 3, 4, 5, 6, 7, 8, 9) :* 10 // the result is (1, 2, 3, 4, 5, 6, 7, 8, 9, 10)}}}
+   */
   def :*[A10](elem: A10): (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10) =
     (t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, elem)
+
   @inline def head: A1 = t._1
+
   def init: (A1, A2, A3, A4, A5, A6, A7, A8) = (t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8)
+
   @inline def last: A9 = t._9
+
   def tail: (A2, A3, A4, A5, A6, A7, A8, A9) = (t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9)
 }
 
 final class Tuple10SyntaxOps[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10](
   private val t: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10)
 ) extends AnyVal {
+
+  /**
+   * Return a copy of `this` tuple with an element prepended.
+   *
+   * @example
+   *   {{{0 *: (1, 2, 3, 4, 5, 6, 7, 8, 9, 10) // the result is (0, 1, 2, 3, 4, 5, 6, 7, 8, 10)}}}
+   */
   def *:[A0](elem: A0): (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10) =
     (elem, t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10)
+
+  /**
+   * Return a copy of `this` tuple with an element appended.
+   *
+   * @example
+   *   {{{(1, 2, 3, 4, 5, 6, 7, 8, 9, 10) :* 11 // the result is (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11)}}}
+   */
   def :*[A11](elem: A11): (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11) =
     (t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10, elem)
+
   @inline def head: A1 = t._1
+
   def init: (A1, A2, A3, A4, A5, A6, A7, A8, A9) = (t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9)
+
   @inline def last: A10 = t._10
+
   def tail: (A2, A3, A4, A5, A6, A7, A8, A9, A10) = (t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10)
 }
 
 final class Tuple11SyntaxOps[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11](
   private val t: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11)
 ) extends AnyVal {
+
+  /**
+   * Return a copy of `this` tuple with an element prepended.
+   */
   def *:[A0](elem: A0): (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11) =
     (elem, t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10, t._11)
+
+  /**
+   * Return a copy of `this` tuple with an element appended.
+   */
   def :*[A12](elem: A12): (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12) =
     (t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10, t._11, elem)
+
   @inline def head: A1 = t._1
+
   def init: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10) = (t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10)
+
   @inline def last: A11 = t._11
+
   def tail: (A2, A3, A4, A5, A6, A7, A8, A9, A10, A11) = (t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10, t._11)
 }
 
 final class Tuple12SyntaxOps[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12](
   private val t: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12)
 ) extends AnyVal {
+
+  /**
+   * Return a copy of `this` tuple with an element prepended.
+   */
   def *:[A0](elem: A0): (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12) =
     (elem, t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10, t._11, t._12)
+
+  /**
+   * Return a copy of `this` tuple with an element appended.
+   */
   def :*[A13](elem: A13): (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13) =
     (t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10, t._11, t._12, elem)
+
   @inline def head: A1 = t._1
+
   def init: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11) =
     (t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10, t._11)
+
   @inline def last: A12 = t._12
   def tail: (A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12) =
     (t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10, t._11, t._12)
@@ -204,14 +387,26 @@ final class Tuple12SyntaxOps[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12](
 final class Tuple13SyntaxOps[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13](
   private val t: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13)
 ) extends AnyVal {
+
+  /**
+   * Return a copy of `this` tuple with an element prepended.
+   */
   def *:[A0](elem: A0): (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13) =
     (elem, t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10, t._11, t._12, t._13)
+
+  /**
+   * Return a copy of `this` tuple with an element appended.
+   */
   def :*[A14](elem: A14): (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14) =
     (t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10, t._11, t._12, t._13, elem)
+
   @inline def head: A1 = t._1
+
   def init: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12) =
     (t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10, t._11, t._12)
+
   @inline def last: A13 = t._13
+
   def tail: (A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13) =
     (t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10, t._11, t._12, t._13)
 }
@@ -219,14 +414,26 @@ final class Tuple13SyntaxOps[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, 
 final class Tuple14SyntaxOps[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14](
   private val t: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14)
 ) extends AnyVal {
+
+  /**
+   * Return a copy of `this` tuple with an element prepended.
+   */
   def *:[A0](elem: A0): (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14) =
     (elem, t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10, t._11, t._12, t._13, t._14)
+
+  /**
+   * Return a copy of `this` tuple with an element appended.
+   */
   def :*[A15](elem: A15): (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15) =
     (t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10, t._11, t._12, t._13, t._14, elem)
+
   @inline def head: A1 = t._1
+
   def init: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13) =
     (t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10, t._11, t._12, t._13)
+
   @inline def last: A14 = t._14
+
   def tail: (A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14) =
     (t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10, t._11, t._12, t._13, t._14)
 }
@@ -234,14 +441,26 @@ final class Tuple14SyntaxOps[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, 
 final class Tuple15SyntaxOps[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15](
   private val t: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15)
 ) extends AnyVal {
+
+  /**
+   * Return a copy of `this` tuple with an element prepended.
+   */
   def *:[A0](elem: A0): (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15) =
     (elem, t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10, t._11, t._12, t._13, t._14, t._15)
+
+  /**
+   * Return a copy of `this` tuple with an element appended.
+   */
   def :*[A16](elem: A16): (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16) =
     (t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10, t._11, t._12, t._13, t._14, t._15, elem)
+
   @inline def head: A1 = t._1
+
   def init: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14) =
     (t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10, t._11, t._12, t._13, t._14)
+
   @inline def last: A15 = t._15
+
   def tail: (A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15) =
     (t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10, t._11, t._12, t._13, t._14, t._15)
 }
@@ -249,14 +468,26 @@ final class Tuple15SyntaxOps[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, 
 final class Tuple16SyntaxOps[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16](
   private val t: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16)
 ) extends AnyVal {
+
+  /**
+   * Return a copy of `this` tuple with an element prepended.
+   */
   def *:[A0](elem: A0): (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16) =
     (elem, t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10, t._11, t._12, t._13, t._14, t._15, t._16)
+
+  /**
+   * Return a copy of `this` tuple with an element appended.
+   */
   def :*[A17](elem: A17): (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17) =
     (t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10, t._11, t._12, t._13, t._14, t._15, t._16, elem)
+
   @inline def head: A1 = t._1
+
   def init: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15) =
     (t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10, t._11, t._12, t._13, t._14, t._15)
+
   @inline def last: A16 = t._16
+
   def tail: (A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16) =
     (t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10, t._11, t._12, t._13, t._14, t._15, t._16)
 }
@@ -264,14 +495,26 @@ final class Tuple16SyntaxOps[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, 
 final class Tuple17SyntaxOps[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17](
   private val t: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17)
 ) extends AnyVal {
+
+  /**
+   * Return a copy of `this` tuple with an element prepended.
+   */
   def *:[A0](elem: A0): (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17) =
     (elem, t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10, t._11, t._12, t._13, t._14, t._15, t._16, t._17)
+
+  /**
+   * Return a copy of `this` tuple with an element appended.
+   */
   def :*[A18](elem: A18): (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18) =
     (t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10, t._11, t._12, t._13, t._14, t._15, t._16, t._17, elem)
+
   @inline def head: A1 = t._1
+
   def init: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16) =
     (t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10, t._11, t._12, t._13, t._14, t._15, t._16)
+
   @inline def last: A17 = t._17
+
   def tail: (A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17) =
     (t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10, t._11, t._12, t._13, t._14, t._15, t._16, t._17)
 }
@@ -280,14 +523,28 @@ final class Tuple17SyntaxOps[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, 
 final class Tuple18SyntaxOps[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18](
   private val t: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18)
 ) extends AnyVal {
+
+  /**
+   * Return a copy of `this` tuple with an element prepended.
+   */
   def *:[A0](elem: A0): (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18) =
-    (elem, t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10, t._11, t._12, t._13, t._14, t._15, t._16, t._17, t._18)
+    (elem, t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8,
+      t._9, t._10, t._11, t._12, t._13, t._14, t._15, t._16, t._17, t._18)
+
+  /**
+   * Return a copy of `this` tuple with an element appended.
+   */
   def :*[A19](elem: A19): (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19) =
-    (t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10, t._11, t._12, t._13, t._14, t._15, t._16, t._17, t._18, elem)
+    (t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9,
+      t._10, t._11, t._12, t._13, t._14, t._15, t._16, t._17, t._18, elem)
+
   @inline def head: A1 = t._1
+
   def init: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17) =
     (t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10, t._11, t._12, t._13, t._14, t._15, t._16, t._17)
+
   @inline def last: A18 = t._18
+
   def tail: (A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18) =
     (t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10, t._11, t._12, t._13, t._14, t._15, t._16, t._17, t._18)
 }
@@ -295,14 +552,28 @@ final class Tuple18SyntaxOps[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, 
 final class Tuple19SyntaxOps[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19](
   private val t: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19)
 ) extends AnyVal {
+
+  /**
+   * Return a copy of `this` tuple with an element prepended.
+   */
   def *:[A0](elem: A0): (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19) =
-    (elem, t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10, t._11, t._12, t._13, t._14, t._15, t._16, t._17, t._18, t._19)
+    (elem, t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9,
+      t._10, t._11, t._12, t._13, t._14, t._15, t._16, t._17, t._18, t._19)
+
+  /**
+   * Return a copy of `this` tuple with an element appended.
+   */
   def :*[A20](elem: A20): (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20) =
-    (t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10, t._11, t._12, t._13, t._14, t._15, t._16, t._17, t._18, t._19, elem)
+    (t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10,
+      t._11, t._12, t._13, t._14, t._15, t._16, t._17, t._18, t._19, elem)
+
   @inline def head: A1 = t._1
+
   def init: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18) =
     (t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10, t._11, t._12, t._13, t._14, t._15, t._16, t._17, t._18)
+
   @inline def last: A19 = t._19
+
   def tail: (A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19) =
     (t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10, t._11, t._12, t._13, t._14, t._15, t._16, t._17, t._18, t._19)
 }
@@ -310,13 +581,29 @@ final class Tuple19SyntaxOps[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, 
 final class Tuple20SyntaxOps[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20](
   private val t: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20)
 ) extends AnyVal {
-  def *:[A0](elem: A0): (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20) = (elem, t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10, t._11, t._12, t._13, t._14, t._15, t._16, t._17, t._18, t._19, t._20)
-  def :*[A21](elem: A21): (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21) = (t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10, t._11, t._12, t._13, t._14, t._15, t._16, t._17, t._18, t._19, t._20, elem)
+
+  /**
+   * Return a copy of `this` tuple with an element prepended.
+   */
+  def *:[A0](elem: A0): (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20) =
+    (elem, t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10,
+      t._11, t._12, t._13, t._14, t._15, t._16, t._17, t._18, t._19, t._20)
+
+  /**
+   * Return a copy of `this` tuple with an element appended.
+   */
+  def :*[A21](elem: A21): (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21) =
+    (t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10,
+      t._11, t._12, t._13, t._14, t._15, t._16, t._17, t._18, t._19, t._20, elem)
+
   @inline def head: A1 = t._1
+
   def init: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19) =
     (t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10,
       t._11, t._12, t._13, t._14, t._15, t._16, t._17, t._18, t._19)
+
   @inline def last: A20 = t._20
+
   def tail: (A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20) =
     (t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10,
       t._11, t._12, t._13, t._14, t._15, t._16, t._17, t._18, t._19, t._20)
@@ -325,15 +612,29 @@ final class Tuple20SyntaxOps[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, 
 final class Tuple21SyntaxOps[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21](
   private val t: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21)
 ) extends AnyVal {
+
+  /**
+   * Return a copy of `this` tuple with an element prepended.
+   */
   def *:[A0](elem: A0): (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21) =
-    (elem, t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10, t._11, t._12, t._13, t._14, t._15, t._16, t._17, t._18, t._19, t._20, t._21)
+    (elem, t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10,
+      t._11, t._12, t._13, t._14, t._15, t._16, t._17, t._18, t._19, t._20, t._21)
+
+  /**
+   * Return a copy of `this` tuple with an element appended.
+   */
   def :*[A22](elem: A22): (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21, A22) =
-    (t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10, t._11, t._12, t._13, t._14, t._15, t._16, t._17, t._18, t._19, t._20, t._21, elem)
+    (t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10,
+      t._11, t._12, t._13, t._14, t._15, t._16, t._17, t._18, t._19, t._20, t._21, elem)
+
   @inline def head: A1 = t._1
+
   def init: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20) =
     (t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10,
       t._11, t._12, t._13, t._14, t._15, t._16, t._17, t._18, t._19, t._20)
+
   @inline def last: A21 = t._21
+
   def tail: (A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21) =
     (t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10,
       t._11, t._12, t._13, t._14, t._15, t._16, t._17, t._18, t._19, t._20, t._21)
@@ -343,10 +644,13 @@ final class Tuple22SyntaxOps[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, 
   private val t: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21, A22)
 ) extends AnyVal {
   @inline def head: A1 = t._1
+
   def init: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21) =
     (t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10,
       t._11, t._12, t._13, t._14, t._15, t._16, t._17, t._18, t._19, t._20, t._21)
+
   @inline def last: A22 = t._22
+
   def tail: (A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21, A22) =
     (t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10,
       t._11, t._12, t._13, t._14, t._15, t._16, t._17, t._18, t._19, t._20, t._21, t._22)

--- a/shared/src/main/scala-2.x/src/main/scala/mouse/tuple.scala
+++ b/shared/src/main/scala-2.x/src/main/scala/mouse/tuple.scala
@@ -89,7 +89,7 @@ trait TupleSyntax {
 final class Tuple2SyntaxOps[A1, A2](private val t: (A1, A2)) extends AnyVal {
 
   /**
-   * Return a copy of `this` tuple with an element prepended.
+   * Return a new tuple by prepending the element to `this` tuple.
    *
    * @example
    *   {{{0 *: (1, 2) // the result is (0, 1, 2)}}}
@@ -97,7 +97,7 @@ final class Tuple2SyntaxOps[A1, A2](private val t: (A1, A2)) extends AnyVal {
   def *:[A0](elem: A0): (A0, A1, A2) = (elem, t._1, t._2)
 
   /**
-   * Return a copy of `this` tuple with an element appended.
+   * Return a copy of `this` tuple with the element appended.
    *
    * @example
    *   {{{(1, 2) :* 3 // the result is (1, 2, 3)}}}
@@ -112,7 +112,7 @@ final class Tuple2SyntaxOps[A1, A2](private val t: (A1, A2)) extends AnyVal {
 final class Tuple3SyntaxOps[A1, A2, A3](private val t: (A1, A2, A3)) extends AnyVal {
 
   /**
-   * Return a copy of `this` tuple with an element prepended.
+   * Return a new tuple by prepending the element to `this` tuple.
    *
    * @example
    *   {{{0 *: (1, 2, 3) // the result is (0, 1, 2, 3)}}}
@@ -120,7 +120,7 @@ final class Tuple3SyntaxOps[A1, A2, A3](private val t: (A1, A2, A3)) extends Any
   def *:[A0](elem: A0): (A0, A1, A2, A3) = (elem, t._1, t._2, t._3)
 
   /**
-   * Return a copy of `this` tuple with an element appended.
+   * Return a copy of `this` tuple with the element appended.
    *
    * @example
    *   {{{(1, 2, 3) :* 4 // the result is (1, 2, 3, 4)}}}
@@ -139,7 +139,7 @@ final class Tuple3SyntaxOps[A1, A2, A3](private val t: (A1, A2, A3)) extends Any
 final class Tuple4SyntaxOps[A1, A2, A3, A4](private val t: (A1, A2, A3, A4)) extends AnyVal {
 
   /**
-   * Return a copy of `this` tuple with an element prepended.
+   * Return a new tuple by prepending the element to `this` tuple.
    *
    * @example
    *   {{{0 *: (1, 2, 3, 4) // the result is (0, 1, 2, 3, 4)}}}
@@ -147,7 +147,7 @@ final class Tuple4SyntaxOps[A1, A2, A3, A4](private val t: (A1, A2, A3, A4)) ext
   def *:[A0](elem: A0): (A0, A1, A2, A3, A4) = (elem, t._1, t._2, t._3, t._4)
 
   /**
-   * Return a copy of `this` tuple with an element appended.
+   * Return a copy of `this` tuple with the element appended.
    *
    * @example
    *   {{{(1, 2, 3, 4) :* 5 // the result is (1, 2, 3, 4, 5)}}}
@@ -166,7 +166,7 @@ final class Tuple4SyntaxOps[A1, A2, A3, A4](private val t: (A1, A2, A3, A4)) ext
 final class Tuple5SyntaxOps[A1, A2, A3, A4, A5](private val t: (A1, A2, A3, A4, A5)) extends AnyVal {
 
   /**
-   * Return a copy of `this` tuple with an element prepended.
+   * Return a new tuple by prepending the element to `this` tuple.
    *
    * @example
    *   {{{0 *: (1, 2, 3, 4, 5) // the result is (0, 1, 2, 3, 4, 5)}}}
@@ -174,7 +174,7 @@ final class Tuple5SyntaxOps[A1, A2, A3, A4, A5](private val t: (A1, A2, A3, A4, 
   def *:[A0](elem: A0): (A0, A1, A2, A3, A4, A5) = (elem, t._1, t._2, t._3, t._4, t._5)
 
   /**
-   * Return a copy of `this` tuple with an element appended.
+   * Return a copy of `this` tuple with the element appended.
    *
    * @example
    *   {{{(1, 2, 3, 4, 5) :* 6 // the result is (1, 2, 3, 4, 5, 6)}}}
@@ -193,7 +193,7 @@ final class Tuple5SyntaxOps[A1, A2, A3, A4, A5](private val t: (A1, A2, A3, A4, 
 final class Tuple6SyntaxOps[A1, A2, A3, A4, A5, A6](private val t: (A1, A2, A3, A4, A5, A6)) extends AnyVal {
 
   /**
-   * Return a copy of `this` tuple with an element prepended.
+   * Return a new tuple by prepending the element to `this` tuple.
    *
    * @example
    *   {{{0 *: (1, 2, 3, 4, 5, 6) // the result is (0, 1, 2, 3, 4, 5, 6)}}}
@@ -201,7 +201,7 @@ final class Tuple6SyntaxOps[A1, A2, A3, A4, A5, A6](private val t: (A1, A2, A3, 
   def *:[A0](elem: A0): (A0, A1, A2, A3, A4, A5, A6) = (elem, t._1, t._2, t._3, t._4, t._5, t._6)
 
   /**
-   * Return a copy of `this` tuple with an element appended.
+   * Return a copy of `this` tuple with the element appended.
    *
    * @example
    *   {{{(1, 2, 3, 4, 5, 6) :* 7 // the result is (1, 2, 3, 4, 5, 6, 7)}}}
@@ -220,7 +220,7 @@ final class Tuple6SyntaxOps[A1, A2, A3, A4, A5, A6](private val t: (A1, A2, A3, 
 final class Tuple7SyntaxOps[A1, A2, A3, A4, A5, A6, A7](private val t: (A1, A2, A3, A4, A5, A6, A7)) extends AnyVal {
 
   /**
-   * Return a copy of `this` tuple with an element prepended.
+   * Return a new tuple by prepending the element to `this` tuple.
    *
    * @example
    *   {{{0 *: (1, 2, 3, 4, 5, 6, 7) // the result is (0, 1, 2, 3, 4, 5, 6, 7)}}}
@@ -228,7 +228,7 @@ final class Tuple7SyntaxOps[A1, A2, A3, A4, A5, A6, A7](private val t: (A1, A2, 
   def *:[A0](elem: A0): (A0, A1, A2, A3, A4, A5, A6, A7) = (elem, t._1, t._2, t._3, t._4, t._5, t._6, t._7)
 
   /**
-   * Return a copy of `this` tuple with an element appended.
+   * Return a copy of `this` tuple with the element appended.
    *
    * @example
    *   {{{(1, 2, 3, 4, 5, 6, 7) :* 8 // the result is (1, 2, 3, 4, 5, 6, 7, 8)}}}
@@ -248,7 +248,7 @@ final class Tuple8SyntaxOps[A1, A2, A3, A4, A5, A6, A7, A8](private val t: (A1, 
     extends AnyVal {
 
   /**
-   * Return a copy of `this` tuple with an element prepended.
+   * Return a new tuple by prepending the element to `this` tuple.
    *
    * @example
    *   {{{0 *: (1, 2, 3, 4, 5, 6, 7, 8) // the result is (0, 1, 2, 3, 4, 5, 6, 7, 8)}}}
@@ -256,7 +256,7 @@ final class Tuple8SyntaxOps[A1, A2, A3, A4, A5, A6, A7, A8](private val t: (A1, 
   def *:[A0](elem: A0): (A0, A1, A2, A3, A4, A5, A6, A7, A8) = (elem, t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8)
 
   /**
-   * Return a copy of `this` tuple with an element appended.
+   * Return a copy of `this` tuple with the element appended.
    *
    * @example
    *   {{{(1, 2, 3, 4, 5, 6, 7, 8) :* 9 // the result is (1, 2, 3, 4, 5, 6, 7, 8, 9)}}}
@@ -276,7 +276,7 @@ final class Tuple9SyntaxOps[A1, A2, A3, A4, A5, A6, A7, A8, A9](private val t: (
     extends AnyVal {
 
   /**
-   * Return a copy of `this` tuple with an element prepended.
+   * Return a new tuple by prepending the element to `this` tuple.
    *
    * @example
    *   {{{0 *: (1, 2, 3, 4, 5, 6, 7, 8, 9) // the result is (0, 1, 2, 3, 4, 5, 6, 7, 8, 9)}}}
@@ -285,7 +285,7 @@ final class Tuple9SyntaxOps[A1, A2, A3, A4, A5, A6, A7, A8, A9](private val t: (
     (elem, t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9)
 
   /**
-   * Return a copy of `this` tuple with an element appended.
+   * Return a copy of `this` tuple with the element appended.
    *
    * @example
    *   {{{(1, 2, 3, 4, 5, 6, 7, 8, 9) :* 10 // the result is (1, 2, 3, 4, 5, 6, 7, 8, 9, 10)}}}
@@ -307,7 +307,7 @@ final class Tuple10SyntaxOps[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10](
 ) extends AnyVal {
 
   /**
-   * Return a copy of `this` tuple with an element prepended.
+   * Return a new tuple by prepending the element to `this` tuple.
    *
    * @example
    *   {{{0 *: (1, 2, 3, 4, 5, 6, 7, 8, 9, 10) // the result is (0, 1, 2, 3, 4, 5, 6, 7, 8, 10)}}}
@@ -316,7 +316,7 @@ final class Tuple10SyntaxOps[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10](
     (elem, t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10)
 
   /**
-   * Return a copy of `this` tuple with an element appended.
+   * Return a copy of `this` tuple with the element appended.
    *
    * @example
    *   {{{(1, 2, 3, 4, 5, 6, 7, 8, 9, 10) :* 11 // the result is (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11)}}}
@@ -338,13 +338,13 @@ final class Tuple11SyntaxOps[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11](
 ) extends AnyVal {
 
   /**
-   * Return a copy of `this` tuple with an element prepended.
+   * Return a new tuple by prepending the element to `this` tuple.
    */
   def *:[A0](elem: A0): (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11) =
     (elem, t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10, t._11)
 
   /**
-   * Return a copy of `this` tuple with an element appended.
+   * Return a copy of `this` tuple with the element appended.
    */
   def :*[A12](elem: A12): (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12) =
     (t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10, t._11, elem)
@@ -363,13 +363,13 @@ final class Tuple12SyntaxOps[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12](
 ) extends AnyVal {
 
   /**
-   * Return a copy of `this` tuple with an element prepended.
+   * Return a new tuple by prepending the element to `this` tuple.
    */
   def *:[A0](elem: A0): (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12) =
     (elem, t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10, t._11, t._12)
 
   /**
-   * Return a copy of `this` tuple with an element appended.
+   * Return a copy of `this` tuple with the element appended.
    */
   def :*[A13](elem: A13): (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13) =
     (t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10, t._11, t._12, elem)
@@ -389,13 +389,13 @@ final class Tuple13SyntaxOps[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, 
 ) extends AnyVal {
 
   /**
-   * Return a copy of `this` tuple with an element prepended.
+   * Return a new tuple by prepending the element to `this` tuple.
    */
   def *:[A0](elem: A0): (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13) =
     (elem, t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10, t._11, t._12, t._13)
 
   /**
-   * Return a copy of `this` tuple with an element appended.
+   * Return a copy of `this` tuple with the element appended.
    */
   def :*[A14](elem: A14): (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14) =
     (t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10, t._11, t._12, t._13, elem)
@@ -416,13 +416,13 @@ final class Tuple14SyntaxOps[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, 
 ) extends AnyVal {
 
   /**
-   * Return a copy of `this` tuple with an element prepended.
+   * Return a new tuple by prepending the element to `this` tuple.
    */
   def *:[A0](elem: A0): (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14) =
     (elem, t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10, t._11, t._12, t._13, t._14)
 
   /**
-   * Return a copy of `this` tuple with an element appended.
+   * Return a copy of `this` tuple with the element appended.
    */
   def :*[A15](elem: A15): (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15) =
     (t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10, t._11, t._12, t._13, t._14, elem)
@@ -443,13 +443,13 @@ final class Tuple15SyntaxOps[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, 
 ) extends AnyVal {
 
   /**
-   * Return a copy of `this` tuple with an element prepended.
+   * Return a new tuple by prepending the element to `this` tuple.
    */
   def *:[A0](elem: A0): (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15) =
     (elem, t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10, t._11, t._12, t._13, t._14, t._15)
 
   /**
-   * Return a copy of `this` tuple with an element appended.
+   * Return a copy of `this` tuple with the element appended.
    */
   def :*[A16](elem: A16): (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16) =
     (t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10, t._11, t._12, t._13, t._14, t._15, elem)
@@ -470,13 +470,13 @@ final class Tuple16SyntaxOps[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, 
 ) extends AnyVal {
 
   /**
-   * Return a copy of `this` tuple with an element prepended.
+   * Return a new tuple by prepending the element to `this` tuple.
    */
   def *:[A0](elem: A0): (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16) =
     (elem, t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10, t._11, t._12, t._13, t._14, t._15, t._16)
 
   /**
-   * Return a copy of `this` tuple with an element appended.
+   * Return a copy of `this` tuple with the element appended.
    */
   def :*[A17](elem: A17): (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17) =
     (t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10, t._11, t._12, t._13, t._14, t._15, t._16, elem)
@@ -497,13 +497,13 @@ final class Tuple17SyntaxOps[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, 
 ) extends AnyVal {
 
   /**
-   * Return a copy of `this` tuple with an element prepended.
+   * Return a new tuple by prepending the element to `this` tuple.
    */
   def *:[A0](elem: A0): (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17) =
     (elem, t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10, t._11, t._12, t._13, t._14, t._15, t._16, t._17)
 
   /**
-   * Return a copy of `this` tuple with an element appended.
+   * Return a copy of `this` tuple with the element appended.
    */
   def :*[A18](elem: A18): (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18) =
     (t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10, t._11, t._12, t._13, t._14, t._15, t._16, t._17, elem)
@@ -525,14 +525,14 @@ final class Tuple18SyntaxOps[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, 
 ) extends AnyVal {
 
   /**
-   * Return a copy of `this` tuple with an element prepended.
+   * Return a new tuple by prepending the element to `this` tuple.
    */
   def *:[A0](elem: A0): (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18) =
     (elem, t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8,
       t._9, t._10, t._11, t._12, t._13, t._14, t._15, t._16, t._17, t._18)
 
   /**
-   * Return a copy of `this` tuple with an element appended.
+   * Return a copy of `this` tuple with the element appended.
    */
   def :*[A19](elem: A19): (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19) =
     (t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9,
@@ -554,14 +554,14 @@ final class Tuple19SyntaxOps[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, 
 ) extends AnyVal {
 
   /**
-   * Return a copy of `this` tuple with an element prepended.
+   * Return a new tuple by prepending the element to `this` tuple.
    */
   def *:[A0](elem: A0): (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19) =
     (elem, t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9,
       t._10, t._11, t._12, t._13, t._14, t._15, t._16, t._17, t._18, t._19)
 
   /**
-   * Return a copy of `this` tuple with an element appended.
+   * Return a copy of `this` tuple with the element appended.
    */
   def :*[A20](elem: A20): (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20) =
     (t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10,
@@ -583,14 +583,14 @@ final class Tuple20SyntaxOps[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, 
 ) extends AnyVal {
 
   /**
-   * Return a copy of `this` tuple with an element prepended.
+   * Return a new tuple by prepending the element to `this` tuple.
    */
   def *:[A0](elem: A0): (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20) =
     (elem, t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10,
       t._11, t._12, t._13, t._14, t._15, t._16, t._17, t._18, t._19, t._20)
 
   /**
-   * Return a copy of `this` tuple with an element appended.
+   * Return a copy of `this` tuple with the element appended.
    */
   def :*[A21](elem: A21): (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21) =
     (t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10,
@@ -614,14 +614,14 @@ final class Tuple21SyntaxOps[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, 
 ) extends AnyVal {
 
   /**
-   * Return a copy of `this` tuple with an element prepended.
+   * Return a new tuple by prepending the element to `this` tuple.
    */
   def *:[A0](elem: A0): (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21) =
     (elem, t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10,
       t._11, t._12, t._13, t._14, t._15, t._16, t._17, t._18, t._19, t._20, t._21)
 
   /**
-   * Return a copy of `this` tuple with an element appended.
+   * Return a copy of `this` tuple with the element appended.
    */
   def :*[A22](elem: A22): (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21, A22) =
     (t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10,

--- a/shared/src/main/scala-2.x/src/main/scala/mouse/tuple.scala
+++ b/shared/src/main/scala-2.x/src/main/scala/mouse/tuple.scala
@@ -87,11 +87,15 @@ trait TupleSyntax {
 }
 
 final class Tuple2SyntaxOps[A1, A2](private val t: (A1, A2)) extends AnyVal {
+  def *:[A0](elem: A0): (A0, A1, A2) = (elem, t._1, t._2)
+  def :*[A3](elem: A3): (A1, A2, A3) = (t._1, t._2, elem)
   @inline def head: A1 = t._1
   @inline def last: A2 = t._2
 }
 
 final class Tuple3SyntaxOps[A1, A2, A3](private val t: (A1, A2, A3)) extends AnyVal {
+  def *:[A0](elem: A0): (A0, A1, A2, A3) = (elem, t._1, t._2, t._3)
+  def :*[A4](elem: A4): (A1, A2, A3, A4) = (t._1, t._2, t._3, elem)
   @inline def head: A1 = t._1
   def init: (A1, A2) = (t._1, t._2)
   @inline def last: A3 = t._3
@@ -99,6 +103,8 @@ final class Tuple3SyntaxOps[A1, A2, A3](private val t: (A1, A2, A3)) extends Any
 }
 
 final class Tuple4SyntaxOps[A1, A2, A3, A4](private val t: (A1, A2, A3, A4)) extends AnyVal {
+  def *:[A0](elem: A0): (A0, A1, A2, A3, A4) = (elem, t._1, t._2, t._3, t._4)
+  def :*[A5](elem: A5): (A1, A2, A3, A4, A5) = (t._1, t._2, t._3, t._4, elem)
   @inline def head: A1 = t._1
   def init: (A1, A2, A3) = (t._1, t._2, t._3)
   @inline def last: A4 = t._4
@@ -106,6 +112,8 @@ final class Tuple4SyntaxOps[A1, A2, A3, A4](private val t: (A1, A2, A3, A4)) ext
 }
 
 final class Tuple5SyntaxOps[A1, A2, A3, A4, A5](private val t: (A1, A2, A3, A4, A5)) extends AnyVal {
+  def *:[A0](elem: A0): (A0, A1, A2, A3, A4, A5) = (elem, t._1, t._2, t._3, t._4, t._5)
+  def :*[A6](elem: A6): (A1, A2, A3, A4, A5, A6) = (t._1, t._2, t._3, t._4, t._5, elem)
   @inline def head: A1 = t._1
   def init: (A1, A2, A3, A4) = (t._1, t._2, t._3, t._4)
   @inline def last: A5 = t._5
@@ -113,6 +121,8 @@ final class Tuple5SyntaxOps[A1, A2, A3, A4, A5](private val t: (A1, A2, A3, A4, 
 }
 
 final class Tuple6SyntaxOps[A1, A2, A3, A4, A5, A6](private val t: (A1, A2, A3, A4, A5, A6)) extends AnyVal {
+  def *:[A0](elem: A0): (A0, A1, A2, A3, A4, A5, A6) = (elem, t._1, t._2, t._3, t._4, t._5, t._6)
+  def :*[A7](elem: A7): (A1, A2, A3, A4, A5, A6, A7) = (t._1, t._2, t._3, t._4, t._5, t._6, elem)
   @inline def head: A1 = t._1
   def init: (A1, A2, A3, A4, A5) = (t._1, t._2, t._3, t._4, t._5)
   @inline def last: A6 = t._6
@@ -120,6 +130,8 @@ final class Tuple6SyntaxOps[A1, A2, A3, A4, A5, A6](private val t: (A1, A2, A3, 
 }
 
 final class Tuple7SyntaxOps[A1, A2, A3, A4, A5, A6, A7](private val t: (A1, A2, A3, A4, A5, A6, A7)) extends AnyVal {
+  def *:[A0](elem: A0): (A0, A1, A2, A3, A4, A5, A6, A7) = (elem, t._1, t._2, t._3, t._4, t._5, t._6, t._7)
+  def :*[A8](elem: A8): (A1, A2, A3, A4, A5, A6, A7, A8) = (t._1, t._2, t._3, t._4, t._5, t._6, t._7, elem)
   @inline def head: A1 = t._1
   def init: (A1, A2, A3, A4, A5, A6) = (t._1, t._2, t._3, t._4, t._5, t._6)
   @inline def last: A7 = t._7
@@ -128,6 +140,8 @@ final class Tuple7SyntaxOps[A1, A2, A3, A4, A5, A6, A7](private val t: (A1, A2, 
 
 final class Tuple8SyntaxOps[A1, A2, A3, A4, A5, A6, A7, A8](private val t: (A1, A2, A3, A4, A5, A6, A7, A8))
     extends AnyVal {
+  def *:[A0](elem: A0): (A0, A1, A2, A3, A4, A5, A6, A7, A8) = (elem, t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8)
+  def :*[A9](elem: A9): (A1, A2, A3, A4, A5, A6, A7, A8, A9) = (t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, elem)
   @inline def head: A1 = t._1
   def init: (A1, A2, A3, A4, A5, A6, A7) = (t._1, t._2, t._3, t._4, t._5, t._6, t._7)
   @inline def last: A8 = t._8
@@ -136,6 +150,10 @@ final class Tuple8SyntaxOps[A1, A2, A3, A4, A5, A6, A7, A8](private val t: (A1, 
 
 final class Tuple9SyntaxOps[A1, A2, A3, A4, A5, A6, A7, A8, A9](private val t: (A1, A2, A3, A4, A5, A6, A7, A8, A9))
     extends AnyVal {
+  def *:[A0](elem: A0): (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9) =
+    (elem, t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9)
+  def :*[A10](elem: A10): (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10) =
+    (t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, elem)
   @inline def head: A1 = t._1
   def init: (A1, A2, A3, A4, A5, A6, A7, A8) = (t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8)
   @inline def last: A9 = t._9
@@ -145,6 +163,10 @@ final class Tuple9SyntaxOps[A1, A2, A3, A4, A5, A6, A7, A8, A9](private val t: (
 final class Tuple10SyntaxOps[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10](
   private val t: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10)
 ) extends AnyVal {
+  def *:[A0](elem: A0): (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10) =
+    (elem, t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10)
+  def :*[A11](elem: A11): (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11) =
+    (t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10, elem)
   @inline def head: A1 = t._1
   def init: (A1, A2, A3, A4, A5, A6, A7, A8, A9) = (t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9)
   @inline def last: A10 = t._10
@@ -154,6 +176,10 @@ final class Tuple10SyntaxOps[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10](
 final class Tuple11SyntaxOps[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11](
   private val t: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11)
 ) extends AnyVal {
+  def *:[A0](elem: A0): (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11) =
+    (elem, t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10, t._11)
+  def :*[A12](elem: A12): (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12) =
+    (t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10, t._11, elem)
   @inline def head: A1 = t._1
   def init: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10) = (t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10)
   @inline def last: A11 = t._11
@@ -163,6 +189,10 @@ final class Tuple11SyntaxOps[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11](
 final class Tuple12SyntaxOps[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12](
   private val t: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12)
 ) extends AnyVal {
+  def *:[A0](elem: A0): (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12) =
+    (elem, t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10, t._11, t._12)
+  def :*[A13](elem: A13): (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13) =
+    (t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10, t._11, t._12, elem)
   @inline def head: A1 = t._1
   def init: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11) =
     (t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10, t._11)
@@ -174,6 +204,10 @@ final class Tuple12SyntaxOps[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12](
 final class Tuple13SyntaxOps[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13](
   private val t: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13)
 ) extends AnyVal {
+  def *:[A0](elem: A0): (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13) =
+    (elem, t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10, t._11, t._12, t._13)
+  def :*[A14](elem: A14): (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14) =
+    (t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10, t._11, t._12, t._13, elem)
   @inline def head: A1 = t._1
   def init: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12) =
     (t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10, t._11, t._12)
@@ -185,6 +219,10 @@ final class Tuple13SyntaxOps[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, 
 final class Tuple14SyntaxOps[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14](
   private val t: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14)
 ) extends AnyVal {
+  def *:[A0](elem: A0): (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14) =
+    (elem, t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10, t._11, t._12, t._13, t._14)
+  def :*[A15](elem: A15): (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15) =
+    (t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10, t._11, t._12, t._13, t._14, elem)
   @inline def head: A1 = t._1
   def init: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13) =
     (t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10, t._11, t._12, t._13)
@@ -196,6 +234,10 @@ final class Tuple14SyntaxOps[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, 
 final class Tuple15SyntaxOps[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15](
   private val t: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15)
 ) extends AnyVal {
+  def *:[A0](elem: A0): (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15) =
+    (elem, t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10, t._11, t._12, t._13, t._14, t._15)
+  def :*[A16](elem: A16): (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16) =
+    (t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10, t._11, t._12, t._13, t._14, t._15, elem)
   @inline def head: A1 = t._1
   def init: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14) =
     (t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10, t._11, t._12, t._13, t._14)
@@ -207,6 +249,10 @@ final class Tuple15SyntaxOps[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, 
 final class Tuple16SyntaxOps[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16](
   private val t: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16)
 ) extends AnyVal {
+  def *:[A0](elem: A0): (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16) =
+    (elem, t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10, t._11, t._12, t._13, t._14, t._15, t._16)
+  def :*[A17](elem: A17): (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17) =
+    (t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10, t._11, t._12, t._13, t._14, t._15, t._16, elem)
   @inline def head: A1 = t._1
   def init: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15) =
     (t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10, t._11, t._12, t._13, t._14, t._15)
@@ -218,6 +264,10 @@ final class Tuple16SyntaxOps[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, 
 final class Tuple17SyntaxOps[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17](
   private val t: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17)
 ) extends AnyVal {
+  def *:[A0](elem: A0): (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17) =
+    (elem, t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10, t._11, t._12, t._13, t._14, t._15, t._16, t._17)
+  def :*[A18](elem: A18): (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18) =
+    (t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10, t._11, t._12, t._13, t._14, t._15, t._16, t._17, elem)
   @inline def head: A1 = t._1
   def init: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16) =
     (t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10, t._11, t._12, t._13, t._14, t._15, t._16)
@@ -226,9 +276,14 @@ final class Tuple17SyntaxOps[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, 
     (t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10, t._11, t._12, t._13, t._14, t._15, t._16, t._17)
 }
 
+// format: off
 final class Tuple18SyntaxOps[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18](
   private val t: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18)
 ) extends AnyVal {
+  def *:[A0](elem: A0): (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18) =
+    (elem, t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10, t._11, t._12, t._13, t._14, t._15, t._16, t._17, t._18)
+  def :*[A19](elem: A19): (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19) =
+    (t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10, t._11, t._12, t._13, t._14, t._15, t._16, t._17, t._18, elem)
   @inline def head: A1 = t._1
   def init: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17) =
     (t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10, t._11, t._12, t._13, t._14, t._15, t._16, t._17)
@@ -237,10 +292,13 @@ final class Tuple18SyntaxOps[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, 
     (t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10, t._11, t._12, t._13, t._14, t._15, t._16, t._17, t._18)
 }
 
-// format: off
 final class Tuple19SyntaxOps[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19](
   private val t: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19)
 ) extends AnyVal {
+  def *:[A0](elem: A0): (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19) =
+    (elem, t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10, t._11, t._12, t._13, t._14, t._15, t._16, t._17, t._18, t._19)
+  def :*[A20](elem: A20): (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20) =
+    (t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10, t._11, t._12, t._13, t._14, t._15, t._16, t._17, t._18, t._19, elem)
   @inline def head: A1 = t._1
   def init: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18) =
     (t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10, t._11, t._12, t._13, t._14, t._15, t._16, t._17, t._18)
@@ -252,6 +310,8 @@ final class Tuple19SyntaxOps[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, 
 final class Tuple20SyntaxOps[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20](
   private val t: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20)
 ) extends AnyVal {
+  def *:[A0](elem: A0): (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20) = (elem, t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10, t._11, t._12, t._13, t._14, t._15, t._16, t._17, t._18, t._19, t._20)
+  def :*[A21](elem: A21): (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21) = (t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10, t._11, t._12, t._13, t._14, t._15, t._16, t._17, t._18, t._19, t._20, elem)
   @inline def head: A1 = t._1
   def init: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19) =
     (t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10,
@@ -265,6 +325,10 @@ final class Tuple20SyntaxOps[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, 
 final class Tuple21SyntaxOps[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21](
   private val t: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21)
 ) extends AnyVal {
+  def *:[A0](elem: A0): (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21) =
+    (elem, t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10, t._11, t._12, t._13, t._14, t._15, t._16, t._17, t._18, t._19, t._20, t._21)
+  def :*[A22](elem: A22): (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21, A22) =
+    (t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10, t._11, t._12, t._13, t._14, t._15, t._16, t._17, t._18, t._19, t._20, t._21, elem)
   @inline def head: A1 = t._1
   def init: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20) =
     (t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10,

--- a/shared/src/test/scala-2.x/mouse/TupleSyntaxTest.scala
+++ b/shared/src/test/scala-2.x/mouse/TupleSyntaxTest.scala
@@ -55,12 +55,28 @@ class TupleSyntaxTest extends MouseSuite {
     assertEquals((a1, a2).last, a2)
   }
 
+  test("Tuple2Syntax.prepend") {
+    assertEquals(a3 *: (a1, a2), (a3, a1, a2))
+  }
+
+  test("Tuple2Syntax.append") {
+    assertEquals((a1, a2) :* a3, (a1, a2, a3))
+  }
+
   test("Tuple3Syntax.init") {
     assertEquals((a1, a2, a3).init, (a1, a2))
   }
 
   test("Tuple3Syntax.head") {
     assertEquals((a1, a2, a3).head, a1)
+  }
+
+  test("Tuple3Syntax.prepend") {
+    assertEquals(a4 *: (a1, a2, a3), (a4, a1, a2, a3))
+  }
+
+  test("Tuple3Syntax.append") {
+    assertEquals((a1, a2, a3) :* a4, (a1, a2, a3, a4))
   }
 
   test("Tuple3Syntax.last") {
@@ -87,6 +103,14 @@ class TupleSyntaxTest extends MouseSuite {
     assertEquals((a1, a2, a3, a4).tail, (a2, a3, a4))
   }
 
+  test("Tuple4Syntax.prepend") {
+    assertEquals(a5 *: (a1, a2, a3, a4), (a5, a1, a2, a3, a4))
+  }
+
+  test("Tuple4Syntax.append") {
+    assertEquals((a1, a2, a3, a4) :* a5, (a1, a2, a3, a4, a5))
+  }
+
   test("Tuple5Syntax.init") {
     assertEquals((a1, a2, a3, a4, a5).init, (a1, a2, a3, a4))
   }
@@ -101,6 +125,14 @@ class TupleSyntaxTest extends MouseSuite {
 
   test("Tuple5Syntax.tail") {
     assertEquals((a1, a2, a3, a4, a5).tail, (a2, a3, a4, a5))
+  }
+
+  test("Tuple5Syntax.append") {
+    assertEquals((a1, a2, a3, a4, a5) :* a6, (a1, a2, a3, a4, a5, a6))
+  }
+
+  test("Tuple5Syntax.prepend") {
+    assertEquals(a6 *: (a1, a2, a3, a4, a5), (a6, a1, a2, a3, a4, a5))
   }
 
   test("Tuple6Syntax.init") {
@@ -119,6 +151,14 @@ class TupleSyntaxTest extends MouseSuite {
     assertEquals((a1, a2, a3, a4, a5, a6).tail, (a2, a3, a4, a5, a6))
   }
 
+  test("Tuple6Syntax.append") {
+    assertEquals((a1, a2, a3, a4, a5, a6) :* a7, (a1, a2, a3, a4, a5, a6, a7))
+  }
+
+  test("Tuple6Syntax.prepend") {
+    assertEquals(a7 *: (a1, a2, a3, a4, a5, a6), (a7, a1, a2, a3, a4, a5, a6))
+  }
+
   test("Tuple7Syntax.init") {
     assertEquals((a1, a2, a3, a4, a5, a6, a7).init, (a1, a2, a3, a4, a5, a6))
   }
@@ -133,6 +173,14 @@ class TupleSyntaxTest extends MouseSuite {
 
   test("Tuple7Syntax.tail") {
     assertEquals((a1, a2, a3, a4, a5, a6, a7).tail, (a2, a3, a4, a5, a6, a7))
+  }
+
+  test("Tuple7Syntax.append") {
+    assertEquals((a1, a2, a3, a4, a5, a6, a7) :* a8, (a1, a2, a3, a4, a5, a6, a7, a8))
+  }
+
+  test("Tuple7Syntax.prepend") {
+    assertEquals(a8 *: (a1, a2, a3, a4, a5, a6, a7), (a8, a1, a2, a3, a4, a5, a6, a7))
   }
 
   test("Tuple8Syntax.init") {
@@ -151,6 +199,14 @@ class TupleSyntaxTest extends MouseSuite {
     assertEquals((a1, a2, a3, a4, a5, a6, a7, a8).tail, (a2, a3, a4, a5, a6, a7, a8))
   }
 
+  test("Tuple8Syntax.append") {
+    assertEquals((a1, a2, a3, a4, a5, a6, a7, a8) :* a9, (a1, a2, a3, a4, a5, a6, a7, a8, a9))
+  }
+
+  test("Tuple8Syntax.prepend") {
+    assertEquals(a9 *: (a1, a2, a3, a4, a5, a6, a7, a8), (a9, a1, a2, a3, a4, a5, a6, a7, a8))
+  }
+
   test("Tuple9Syntax.init") {
     assertEquals((a1, a2, a3, a4, a5, a6, a7, a8, a9).init, (a1, a2, a3, a4, a5, a6, a7, a8))
   }
@@ -165,6 +221,14 @@ class TupleSyntaxTest extends MouseSuite {
 
   test("Tuple9Syntax.tail") {
     assertEquals((a1, a2, a3, a4, a5, a6, a7, a8, a9).tail, (a2, a3, a4, a5, a6, a7, a8, a9))
+  }
+
+  test("Tuple9Syntax.append") {
+    assertEquals((a1, a2, a3, a4, a5, a6, a7, a8, a9) :* a10, (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10))
+  }
+
+  test("Tuple9Syntax.prepend") {
+    assertEquals(a10 *: (a1, a2, a3, a4, a5, a6, a7, a8, a9), (a10, a1, a2, a3, a4, a5, a6, a7, a8, a9))
   }
 
   test("Tuple10Syntax.init") {
@@ -183,6 +247,14 @@ class TupleSyntaxTest extends MouseSuite {
     assertEquals((a1, a2, a3, a4, a5, a6, a7, a8, a9, a10).tail, (a2, a3, a4, a5, a6, a7, a8, a9, a10))
   }
 
+  test("Tuple10Syntax.append") {
+    assertEquals((a1, a2, a3, a4, a5, a6, a7, a8, a9, a10) :* a11, (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11))
+  }
+
+  test("Tuple10Syntax.prepend") {
+    assertEquals(a11 *: (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10), (a11, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10))
+  }
+
   test("Tuple11Syntax.init") {
     assertEquals((a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11).init, (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10))
   }
@@ -197,6 +269,18 @@ class TupleSyntaxTest extends MouseSuite {
 
   test("Tuple11Syntax.tail") {
     assertEquals((a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11).tail, (a2, a3, a4, a5, a6, a7, a8, a9, a10, a11))
+  }
+
+  test("Tuple11Syntax.append") {
+    assertEquals((a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11) :* a12,
+                 (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12)
+    )
+  }
+
+  test("Tuple11Syntax.prepend") {
+    assertEquals(a12 *: (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11),
+                 (a12, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11)
+    )
   }
 
   test("Tuple12Syntax.init") {
@@ -216,6 +300,18 @@ class TupleSyntaxTest extends MouseSuite {
   test("Tuple12Syntax.tail") {
     assertEquals((a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12).tail,
                  (a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12)
+    )
+  }
+
+  test("Tuple12Syntax.append") {
+    assertEquals((a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12) :* a13,
+                 (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13)
+    )
+  }
+
+  test("Tuple12Syntax.prepend") {
+    assertEquals(a13 *: (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12),
+                 (a13, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12)
     )
   }
 
@@ -239,6 +335,18 @@ class TupleSyntaxTest extends MouseSuite {
     )
   }
 
+  test("Tuple13Syntax.append") {
+    assertEquals((a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13) :* a14,
+                 (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14)
+    )
+  }
+
+  test("Tuple13Syntax.prepend") {
+    assertEquals(a14 *: (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13),
+                 (a14, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13)
+    )
+  }
+
   test("Tuple14Syntax.init") {
     assertEquals((a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14).init,
                  (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13)
@@ -256,6 +364,18 @@ class TupleSyntaxTest extends MouseSuite {
   test("Tuple14Syntax.tail") {
     assertEquals((a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14).tail,
                  (a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14)
+    )
+  }
+
+  test("Tuple14Syntax.append") {
+    assertEquals((a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14) :* a15,
+                 (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15)
+    )
+  }
+
+  test("Tuple14Syntax.prepend") {
+    assertEquals(a15 *: (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14),
+                 (a15, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14)
     )
   }
 
@@ -279,6 +399,18 @@ class TupleSyntaxTest extends MouseSuite {
     )
   }
 
+  test("Tuple15Syntax.append") {
+    assertEquals((a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15) :* a16,
+                 (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16)
+    )
+  }
+
+  test("Tuple15Syntax.prepend") {
+    assertEquals(a16 *: (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15),
+                 (a16, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15)
+    )
+  }
+
   test("Tuple16Syntax.init") {
     assertEquals((a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16).init,
                  (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15)
@@ -296,6 +428,18 @@ class TupleSyntaxTest extends MouseSuite {
   test("Tuple16Syntax.tail") {
     assertEquals((a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16).tail,
                  (a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16)
+    )
+  }
+
+  test("Tuple16Syntax.append") {
+    assertEquals((a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16) :* a17,
+                 (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17)
+    )
+  }
+
+  test("Tuple16Syntax.prepend") {
+    assertEquals(a17 *: (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16),
+                 (a17, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16)
     )
   }
 
@@ -319,6 +463,18 @@ class TupleSyntaxTest extends MouseSuite {
     )
   }
 
+  test("Tuple17Syntax.append") {
+    assertEquals((a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17) :* a18,
+                 (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18)
+    )
+  }
+
+  test("Tuple17Syntax.prepend") {
+    assertEquals(a18 *: (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17),
+                 (a18, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17)
+    )
+  }
+
   test("Tuple18Syntax.init") {
     assertEquals((a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18).init,
                  (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17)
@@ -336,6 +492,18 @@ class TupleSyntaxTest extends MouseSuite {
   test("Tuple18Syntax.tail") {
     assertEquals((a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18).tail,
                  (a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18)
+    )
+  }
+
+  test("Tuple18Syntax.append") {
+    assertEquals((a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18) :* a19,
+                 (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19)
+    )
+  }
+
+  test("Tuple18Syntax.prepend") {
+    assertEquals(a19 *: (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18),
+                 (a19, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18)
     )
   }
 
@@ -359,6 +527,18 @@ class TupleSyntaxTest extends MouseSuite {
     )
   }
 
+  test("Tuple19Syntax.append") {
+    assertEquals((a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19) :* a20,
+                 (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20)
+    )
+  }
+
+  test("Tuple19Syntax.prepend") {
+    assertEquals(a20 *: (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19),
+                 (a20, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19)
+    )
+  }
+
   test("Tuple20Syntax.init") {
     assertEquals((a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20).init,
                  (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19)
@@ -376,6 +556,20 @@ class TupleSyntaxTest extends MouseSuite {
   test("Tuple20Syntax.tail") {
     assertEquals((a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20).tail,
                  (a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20)
+    )
+  }
+
+  test("Tuple20Syntax.append") {
+    assertEquals(
+      (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20) :* a21,
+      (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21)
+    )
+  }
+
+  test("Tuple20Syntax.prepend") {
+    assertEquals(
+      a21 *: (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20),
+      (a21, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20)
     )
   }
 
@@ -403,6 +597,20 @@ class TupleSyntaxTest extends MouseSuite {
     assertEquals(
       (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21).tail,
       (a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21)
+    )
+  }
+
+  test("Tuple21Syntax.append") {
+    assertEquals(
+      (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21) :* a22,
+      (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22)
+    )
+  }
+
+  test("Tuple21Syntax.prepend") {
+    assertEquals(
+      a22 *: (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21),
+      (a22, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21)
     )
   }
 


### PR DESCRIPTION
The notation of that operators is taken from Scala 3 `Tuple` methods:
`*:` — stands for `prepend` https://github.com/lampepfl/dotty/blob/master/library/src/scala/Tuple.scala#L32
`:*` — stands for `append` https://github.com/lampepfl/dotty/blob/master/library/src/scala/Tuple.scala#L26
It'll allow smooth migration on Scala 3 by simply deleting the `mouse.tuple._` import.