### PR TITLE
Enhanced syntax for creation EitherT/OptionT

### DIFF
--- a/shared/src/main/scala/mouse/anyf.scala
+++ b/shared/src/main/scala/mouse/anyf.scala
@@ -13,10 +13,10 @@ final class AnyFOps[F[_], A](private val fa: F[A]) extends AnyVal {
   @inline def ||>[G[_]](f: F ~> G): G[A] = f(fa)
   @inline def thrushK[G[_]](f: F ~> G): G[A] = f(fa)
 
-  def liftRightT[E](implicit F: Functor[F]): EitherT[F, E, A] =
+  def liftEitherT[E](implicit F: Functor[F]): EitherT[F, E, A] =
     EitherT.right[E](fa)
 
-  def liftSomeT(implicit F: Functor[F]): OptionT[F, A] =
+  def liftOptionT(implicit F: Functor[F]): OptionT[F, A] =
     OptionT.liftF(fa)
 
 }

--- a/shared/src/main/scala/mouse/anyf.scala
+++ b/shared/src/main/scala/mouse/anyf.scala
@@ -13,10 +13,10 @@ final class AnyFOps[F[_], A](private val fa: F[A]) extends AnyVal {
   @inline def ||>[G[_]](f: F ~> G): G[A] = f(fa)
   @inline def thrushK[G[_]](f: F ~> G): G[A] = f(fa)
 
-  def liftEitherT[E](implicit F: Functor[F]): EitherT[F, E, A] =
+  def liftRightT[E](implicit F: Functor[F]): EitherT[F, E, A] =
     EitherT.right[E](fa)
 
-  def liftOptionT(implicit F: Functor[F]): OptionT[F, A] =
+  def liftSomeT(implicit F: Functor[F]): OptionT[F, A] =
     OptionT.liftF(fa)
 
 }

--- a/shared/src/main/scala/mouse/anyf.scala
+++ b/shared/src/main/scala/mouse/anyf.scala
@@ -1,5 +1,9 @@
 package mouse
+
+import cats.data.EitherT
+import cats.data.OptionT
 import cats.~>
+import cats.Functor
 
 trait AnyFSyntax {
   implicit final def anyfSyntaxMouse[F[_], A](fa: F[A]): AnyFOps[F, A] = new AnyFOps(fa)
@@ -8,4 +12,11 @@ trait AnyFSyntax {
 final class AnyFOps[F[_], A](private val fa: F[A]) extends AnyVal {
   @inline def ||>[G[_]](f: F ~> G): G[A] = f(fa)
   @inline def thrushK[G[_]](f: F ~> G): G[A] = f(fa)
+
+  def liftEitherT[E](implicit F: Functor[F]): EitherT[F, E, A] =
+    EitherT.right[E](fa)
+
+  def liftOptionT(implicit F: Functor[F]): OptionT[F, A] =
+    OptionT.liftF(fa)
+
 }

--- a/shared/src/main/scala/mouse/foption.scala
+++ b/shared/src/main/scala/mouse/foption.scala
@@ -1,5 +1,6 @@
 package mouse
 
+import cats.data.EitherT
 import cats.data.OptionT
 import cats.{Applicative, FlatMap, Functor, Monad, Traverse}
 
@@ -87,4 +88,7 @@ final class FOptionOps[F[_], A](private val foa: F[Option[A]]) extends AnyVal {
 
   def liftOptionT: OptionT[F, A] =
     OptionT(foa)
+
+  def liftEitherT[E](ifNone: => E)(implicit F: Functor[F]): EitherT[F, E, A] =
+    EitherT.fromOptionF(foa, ifNone)
 }

--- a/shared/src/test/scala/mouse/AnyFSyntaxTest.scala
+++ b/shared/src/test/scala/mouse/AnyFSyntaxTest.scala
@@ -1,7 +1,10 @@
 package mouse
 
+import cats.data.EitherT
+import cats.data.OptionT
 import cats.syntax.option._
 import cats.syntax.functor._
+import cats.syntax.either._
 import cats.{~>, Id}
 
 class AnyFSyntaxTest extends MouseSuite {
@@ -38,5 +41,13 @@ class AnyFSyntaxTest extends MouseSuite {
       List("This") ||> double ||> headOption ||> optionGet,
       "This"
     )
+  }
+
+  test("AnyFSyntax.liftEitherT") {
+    assertEquals(List(1).liftEitherT[String], EitherT(List(1.asRight[String])))
+  }
+
+  test("AnyFSyntax.liftOptionT") {
+    assertEquals(List(1).liftOptionT, OptionT(List(Option(1))))
   }
 }

--- a/shared/src/test/scala/mouse/AnyFSyntaxTest.scala
+++ b/shared/src/test/scala/mouse/AnyFSyntaxTest.scala
@@ -43,11 +43,11 @@ class AnyFSyntaxTest extends MouseSuite {
     )
   }
 
-  test("AnyFSyntax.liftEitherT") {
-    assertEquals(List(1).liftEitherT[String], EitherT(List(1.asRight[String])))
+  test("AnyFSyntax.liftRightT") {
+    assertEquals(List(1).liftRightT[String], EitherT(List(1.asRight[String])))
   }
 
-  test("AnyFSyntax.liftOptionT") {
-    assertEquals(List(1).liftOptionT, OptionT(List(Option(1))))
+  test("AnyFSyntax.liftSomeT") {
+    assertEquals(List(1).liftSomeT, OptionT(List(Option(1))))
   }
 }

--- a/shared/src/test/scala/mouse/AnyFSyntaxTest.scala
+++ b/shared/src/test/scala/mouse/AnyFSyntaxTest.scala
@@ -43,11 +43,11 @@ class AnyFSyntaxTest extends MouseSuite {
     )
   }
 
-  test("AnyFSyntax.liftRightT") {
-    assertEquals(List(1).liftRightT[String], EitherT(List(1.asRight[String])))
+  test("AnyFSyntax.liftEitherT") {
+    assertEquals(List(1).liftEitherT[String], EitherT(List(1.asRight[String])))
   }
 
-  test("AnyFSyntax.liftSomeT") {
-    assertEquals(List(1).liftSomeT, OptionT(List(Option(1))))
+  test("AnyFSyntax.liftOptionT") {
+    assertEquals(List(1).liftOptionT, OptionT(List(Option(1))))
   }
 }

--- a/shared/src/test/scala/mouse/FOptionSyntaxTest.scala
+++ b/shared/src/test/scala/mouse/FOptionSyntaxTest.scala
@@ -1,6 +1,8 @@
 package mouse
 
 import cats.data.OptionT
+import cats.data.EitherT
+import cats.syntax.either._
 
 class FOptionSyntaxTest extends MouseSuite {
   test("FOptionSyntax.cata") {
@@ -109,5 +111,10 @@ class FOptionSyntaxTest extends MouseSuite {
   test("FOptionSyntax.liftOptionT") {
     assertEquals(List(Option(1)).liftOptionT, OptionT(List(Option(1))))
     assertEquals(List(Option.empty[Int]).liftOptionT, OptionT(List(Option.empty[Int])))
+  }
+
+  test("FOptionSyntax.liftEitherT") {
+    assertEquals(List(Option(1)).liftEitherT("none"), EitherT(List(1.asRight[String])))
+    assertEquals(List(Option.empty[Int]).liftEitherT("none"), EitherT(List("none".asLeft[Int])))
   }
 }


### PR DESCRIPTION
Added convenient methods that enable us to write:

```scala
fa.liftEitherT[E] // EitherT[F, E, A]
fa.liftOptionT // OptionT[F, A]

foptiona.liftEitherT("none") // EitherT[F, String, A]
```

Consequence of https://github.com/typelevel/cats/issues/4068