### PR TITLE
add alternative method to BooleanOps

### DIFF
--- a/shared/src/main/scala/mouse/boolean.scala
+++ b/shared/src/main/scala/mouse/boolean.scala
@@ -2,7 +2,7 @@ package mouse
 
 import cats.data.{EitherNel, NonEmptyList, Validated, ValidatedNel}
 import cats.{Alternative, Applicative, ApplicativeError, Monoid}
-import mouse.BooleanSyntax.LiftToPartiallyApplied
+import mouse.BooleanSyntax._
 
 trait BooleanSyntax {
   implicit final def booleanSyntaxMouse(b: Boolean): BooleanOps = new BooleanOps(b)
@@ -10,11 +10,6 @@ trait BooleanSyntax {
 
 class ApplyIfPartiallyApplied[A](b: Boolean, a: A) {
   @inline def apply[B >: A](f: B => B): B = if (b) f(a) else a
-}
-
-class PureOrEmptyPartiallyApplied[F[_]](b: Boolean) {
-  @inline def apply[A](a: => A)(implicit F: Alternative[F]): F[A] =
-    if (b) F.pure(a) else F.empty
 }
 
 final class BooleanOps(private val b: Boolean) extends AnyVal {
@@ -76,4 +71,10 @@ object BooleanSyntax {
     def apply[E](ifFalse: => E)(implicit F: ApplicativeError[F, _ >: E]): F[Unit] =
       if (b) F.unit else F.raiseError(ifFalse)
   }
+
+  final private[mouse] class PureOrEmptyPartiallyApplied[F[_]](private val b: Boolean) extends AnyVal {
+    def apply[A](a: => A)(implicit F: Alternative[F]): F[A] =
+      if (b) F.pure(a) else F.empty
+  }
+
 }

--- a/shared/src/main/scala/mouse/boolean.scala
+++ b/shared/src/main/scala/mouse/boolean.scala
@@ -14,9 +14,9 @@ class ApplyIfPartiallyApplied[A](b: Boolean, a: A) {
 
 final class BooleanOps(private val b: Boolean) extends AnyVal {
 
-  @inline def option[A](a: => A): Option[A] = pureOrEmpty[Option](a)
+  @inline def option[A](a: => A): Option[A] = alternative[Option](a)
 
-  @inline def pureOrEmpty[F[_]]: PureOrEmptyPartiallyApplied[F] = new PureOrEmptyPartiallyApplied[F](b)
+  @inline def alternative[F[_]]: AlternativePartiallyApplied[F] = new AlternativePartiallyApplied[F](b)
 
   @deprecated("Use `either` instead", "0.6")
   @inline def xor[L, R](l: => L, r: => R): Either[L, R] = either(l, r)
@@ -72,7 +72,7 @@ object BooleanSyntax {
       if (b) F.unit else F.raiseError(ifFalse)
   }
 
-  final private[mouse] class PureOrEmptyPartiallyApplied[F[_]](private val b: Boolean) extends AnyVal {
+  final private[mouse] class AlternativePartiallyApplied[F[_]](private val b: Boolean) extends AnyVal {
     def apply[A](a: => A)(implicit F: Alternative[F]): F[A] =
       if (b) F.pure(a) else F.empty
   }

--- a/shared/src/test/scala/mouse/BooleanSyntaxTest.scala
+++ b/shared/src/test/scala/mouse/BooleanSyntaxTest.scala
@@ -9,7 +9,7 @@ class BooleanSyntaxTest extends MouseSuite {
     assertEquals(false.option(1), Option.empty[Int])
   }
 
-  test("BooleanSyntax.option") {
+  test("BooleanSyntax.pureOrEmpty") {
     assertEquals(true.pureOrEmpty[Vector](1), Vector(1))
     assertEquals(false.pureOrEmpty[Vector](1), Vector.empty[Int])
   }

--- a/shared/src/test/scala/mouse/BooleanSyntaxTest.scala
+++ b/shared/src/test/scala/mouse/BooleanSyntaxTest.scala
@@ -10,8 +10,8 @@ class BooleanSyntaxTest extends MouseSuite {
   }
 
   test("BooleanSyntax.pureOrEmpty") {
-    assertEquals(true.pureOrEmpty[Vector](1), Vector(1))
-    assertEquals(false.pureOrEmpty[Vector](1), Vector.empty[Int])
+    assertEquals(true.alternative[Vector](1), Vector(1))
+    assertEquals(false.alternative[Vector](1), Vector.empty[Int])
   }
 
   test("BooleanSyntax.either") {

--- a/shared/src/test/scala/mouse/BooleanSyntaxTest.scala
+++ b/shared/src/test/scala/mouse/BooleanSyntaxTest.scala
@@ -9,6 +9,11 @@ class BooleanSyntaxTest extends MouseSuite {
     assertEquals(false.option(1), Option.empty[Int])
   }
 
+  test("BooleanSyntax.option") {
+    assertEquals(true.pureOrEmpty[Vector](1), Vector(1))
+    assertEquals(false.pureOrEmpty[Vector](1), Vector.empty[Int])
+  }
+
   test("BooleanSyntax.either") {
     assertEquals(true.either("error", 1), Either.right(1))
     assertEquals(false.either("error", 1), Either.left("error"))


### PR DESCRIPTION
Hi,

This new method works exactly the same as the `option` method in `BooleanOps`, except that it's not restricted to `Option` but works for any type with an `Alternative` instance.

I've needed this often enough to think that it might be useful to other people.