### PR TITLE
Add `asLeftF`, `asRightF`, `noneF`, `someF` methods

### DIFF
--- a/shared/src/main/scala/mouse/any.scala
+++ b/shared/src/main/scala/mouse/any.scala
@@ -26,4 +26,10 @@ final class AnyOps[A](private val a: A) extends AnyVal {
 
   @inline def someF[F[_]](implicit F: Applicative[F]): F[Option[A]] =
     FOptionSyntax.someF[F, A](a)
+
+  @inline def asLeftF[F[_], R](implicit F: Applicative[F]): F[Either[A, R]] =
+    FEitherSyntax.asLeftF[F, A, R](a)
+
+  @inline def asRightF[F[_], L](implicit F: Applicative[F]): F[Either[L, A]] =
+    FEitherSyntax.asRightF[F, L, A](a)
 }

--- a/shared/src/main/scala/mouse/any.scala
+++ b/shared/src/main/scala/mouse/any.scala
@@ -7,9 +7,9 @@ trait AnySyntax {
 }
 
 final class AnyOps[A](private val a: A) extends AnyVal {
-  @inline def |>[B](f: A => B) = f(a)
+  @inline def |>[B](f: A => B): B = f(a)
 
-  @inline def thrush[B](f: A => B) = f(a)
+  @inline def thrush[B](f: A => B): B = f(a)
 
   @inline def <|(f: A => Unit): A = {
     f(a)

--- a/shared/src/main/scala/mouse/any.scala
+++ b/shared/src/main/scala/mouse/any.scala
@@ -21,9 +21,6 @@ final class AnyOps[A](private val a: A) extends AnyVal {
     a
   }
 
-  @inline def noneF[F[_]](implicit F: Applicative[F]): F[Option[A]] =
-    FOptionSyntax.noneF[F, A]
-
   @inline def someF[F[_]](implicit F: Applicative[F]): F[Option[A]] =
     FOptionSyntax.someF[F, A](a)
 

--- a/shared/src/main/scala/mouse/any.scala
+++ b/shared/src/main/scala/mouse/any.scala
@@ -6,24 +6,24 @@ trait AnySyntax {
   implicit final def anySyntaxMouse[A](oa: A): AnyOps[A] = new AnyOps(oa)
 }
 
-final class AnyOps[A](private val oa: A) extends AnyVal {
-  @inline def |>[B](f: A => B) = f(oa)
+final class AnyOps[A](private val a: A) extends AnyVal {
+  @inline def |>[B](f: A => B) = f(a)
 
-  @inline def thrush[B](f: A => B) = f(oa)
+  @inline def thrush[B](f: A => B) = f(a)
 
   @inline def <|(f: A => Unit): A = {
-    f(oa)
-    oa
+    f(a)
+    a
   }
 
   @inline def unsafeTap(f: A => Unit): A = {
-    f(oa)
-    oa
+    f(a)
+    a
   }
 
   @inline def noneF[F[_]](implicit F: Applicative[F]): F[Option[A]] =
     FOptionSyntax.noneF[F, A]
 
   @inline def someF[F[_]](implicit F: Applicative[F]): F[Option[A]] =
-    FOptionSyntax.someF[F, A](oa)
+    FOptionSyntax.someF[F, A](a)
 }

--- a/shared/src/main/scala/mouse/any.scala
+++ b/shared/src/main/scala/mouse/any.scala
@@ -1,18 +1,29 @@
 package mouse
 
+import cats.Applicative
+
 trait AnySyntax {
   implicit final def anySyntaxMouse[A](oa: A): AnyOps[A] = new AnyOps(oa)
 }
 
 final class AnyOps[A](private val oa: A) extends AnyVal {
   @inline def |>[B](f: A => B) = f(oa)
+
   @inline def thrush[B](f: A => B) = f(oa)
+
   @inline def <|(f: A => Unit): A = {
     f(oa)
     oa
   }
+
   @inline def unsafeTap(f: A => Unit): A = {
     f(oa)
     oa
   }
+
+  @inline def noneF[F[_]](implicit F: Applicative[F]): F[Option[A]] =
+    FOptionSyntax.noneF[F, A]
+
+  @inline def someF[F[_]](implicit F: Applicative[F]): F[Option[A]] =
+    FOptionSyntax.someF[F, A](oa)
 }

--- a/shared/src/main/scala/mouse/feither.scala
+++ b/shared/src/main/scala/mouse/feither.scala
@@ -7,7 +7,15 @@ import cats.instances.either._
 trait FEitherSyntax {
   implicit final def FEitherSyntaxMouse[F[_], L, R](felr: F[Either[L, R]]): FEitherOps[F, L, R] =
     new FEitherOps(felr)
+
+  def asLeftF[F[_], L, R](left: => L)(implicit F: Applicative[F]): F[Either[L, R]] =
+    F.pure(Left(left))
+
+  def asRightF[F[_], L, R](right: => R)(implicit F: Applicative[F]): F[Either[L, R]] =
+    F.pure(Right(right))
 }
+
+private[mouse] object FEitherSyntax extends FEitherSyntax
 
 final class FEitherOps[F[_], L, R](private val felr: F[Either[L, R]]) extends AnyVal {
   def cata[A](left: L => A, right: R => A)(implicit F: Functor[F]): F[A] =

--- a/shared/src/main/scala/mouse/foption.scala
+++ b/shared/src/main/scala/mouse/foption.scala
@@ -6,7 +6,15 @@ import cats.{Applicative, FlatMap, Functor, Monad, Traverse}
 
 trait FOptionSyntax {
   implicit final def FOptionSyntaxMouse[F[_], A](foa: F[Option[A]]): FOptionOps[F, A] = new FOptionOps(foa)
+
+  def noneF[F[_], A](implicit F: Applicative[F]): F[Option[A]] =
+    F.pure(None)
+
+  def someF[F[_], A](a: => A)(implicit F: Applicative[F]): F[Option[A]] =
+    F.pure(Some(a))
 }
+
+private[mouse] object FOptionSyntax extends FOptionSyntax
 
 final class FOptionOps[F[_], A](private val foa: F[Option[A]]) extends AnyVal {
 

--- a/shared/src/test/scala/mouse/AnySyntaxTest.scala
+++ b/shared/src/test/scala/mouse/AnySyntaxTest.scala
@@ -19,4 +19,16 @@ class AnySyntaxTest extends MouseSuite with MouseFunctions {
 
     assertEquals("anythingAtAll" |> ignore, ())
   }
+
+  test("AnySyntax.someF") {
+    assertEquals(42.someF[List], List(Option(42)))
+  }
+
+  test("AnySyntax.asLeftF") {
+    assertEquals("".asLeftF[List, Int], List(Left("")))
+  }
+
+  test("AnySyntax.asRightF") {
+    assertEquals(42.asRightF[List, String], List(Right(42)))
+  }
 }

--- a/shared/src/test/scala/mouse/FEitherSyntaxTest.scala
+++ b/shared/src/test/scala/mouse/FEitherSyntaxTest.scala
@@ -101,4 +101,12 @@ class FEitherSyntaxTest extends MouseSuite {
     assertEquals(rightValue.liftEitherT, EitherT(rightValue))
     assertEquals(leftValue.liftEitherT, EitherT(leftValue))
   }
+
+  test("FEitherSyntax.asLeftF") {
+    assertEquals(FEitherSyntax.asLeftF[List, String, Int](""), List(Left("")))
+  }
+
+  test("FEitherSyntax.asRightF") {
+    assertEquals(FEitherSyntax.asRightF[List, String, Int](42), List(Right(42)))
+  }
 }

--- a/shared/src/test/scala/mouse/FOptionSyntaxTest.scala
+++ b/shared/src/test/scala/mouse/FOptionSyntaxTest.scala
@@ -117,4 +117,12 @@ class FOptionSyntaxTest extends MouseSuite {
     assertEquals(List(Option(1)).liftEitherT("none"), EitherT(List(1.asRight[String])))
     assertEquals(List(Option.empty[Int]).liftEitherT("none"), EitherT(List("none".asLeft[Int])))
   }
+
+  test("FOptionSyntax.noneF") {
+    assertEquals(FOptionSyntax.noneF[List, Int], List(None))
+  }
+
+  test("FOptionSyntax.someF") {
+    assertEquals(FOptionSyntax.someF[List, Int](42), List(Some(42)))
+  }
 }


### PR DESCRIPTION
This adds `asLeftF`, `asRightF`, `noneF`, `someF` methods to `AnySyntax`, `FEitherSyntax` and `FOptionSyntax`.
Those methods are utterly useful in daily programming. They're replacing such constructs as:
```scala
none[Int].pure[F] // noneF
42.some.pure[F] // 42.someF
"foo".asLeft[Int].pure[F] // "foo".asLeftF
```