### PR TITLE
Add F[Boolean] syntax

### DIFF
--- a/js/src/main/scala/mouse/package.scala
+++ b/js/src/main/scala/mouse/package.scala
@@ -4,6 +4,7 @@ package object mouse extends MouseFunctions {
   object anyf extends AnyFSyntax
   object boolean extends BooleanSyntax
   object double extends DoubleSyntax
+  object fboolean extends FBooleanSyntax
   object feither extends FEitherSyntax
   object fnested extends FNestedSyntax
   object foption extends FOptionSyntax

--- a/jvm/src/main/scala-2/src/main/scala/mouse/package.scala
+++ b/jvm/src/main/scala-2/src/main/scala/mouse/package.scala
@@ -4,6 +4,7 @@ package object mouse extends MouseFunctions {
   object anyf extends AnyFSyntax
   object boolean extends BooleanSyntax
   object double extends DoubleSyntax
+  object fboolean extends FBooleanSyntax
   object feither extends FEitherSyntax
   object fnested extends FNestedSyntax
   object foption extends FOptionSyntax

--- a/jvm/src/main/scala-3/src/main/scala/mouse/package.scala
+++ b/jvm/src/main/scala-3/src/main/scala/mouse/package.scala
@@ -4,6 +4,7 @@ package object mouse extends MouseFunctions {
   object anyf extends AnyFSyntax
   object boolean extends BooleanSyntax
   object double extends DoubleSyntax
+  object fboolean extends FBooleanSyntax
   object feither extends FEitherSyntax
   object fnested extends FNestedSyntax
   object foption extends FOptionSyntax

--- a/shared/src/main/scala-2/src/main/scala/mouse/all.scala
+++ b/shared/src/main/scala-2/src/main/scala/mouse/all.scala
@@ -3,16 +3,17 @@ package mouse
 trait AllSharedSyntax
     extends AnySyntax
     with AnyFSyntax
-    with OptionSyntax
     with BooleanSyntax
-    with StringSyntax
-    with TrySyntax
-    with IntSyntax
-    with LongSyntax
     with DoubleSyntax
-    with PartialFunctionLift
-    with MapSyntax
-    with FOptionSyntax
+    with FBooleanSyntax
     with FEitherSyntax
     with FNestedSyntax
+    with FOptionSyntax
+    with IntSyntax
+    with LongSyntax
+    with MapSyntax
+    with OptionSyntax
+    with PartialFunctionLift
+    with StringSyntax
+    with TrySyntax
     with TupleSyntax

--- a/shared/src/main/scala-3/src/main/scala/mouse/all.scala
+++ b/shared/src/main/scala-3/src/main/scala/mouse/all.scala
@@ -3,15 +3,16 @@ package mouse
 trait AllSharedSyntax
     extends AnySyntax
     with AnyFSyntax
-    with OptionSyntax
     with BooleanSyntax
-    with StringSyntax
-    with TrySyntax
-    with IntSyntax
-    with LongSyntax
     with DoubleSyntax
-    with PartialFunctionLift
-    with MapSyntax
-    with FOptionSyntax
+    with FBooleanSyntax
     with FEitherSyntax
     with FNestedSyntax
+    with FOptionSyntax
+    with IntSyntax
+    with LongSyntax
+    with MapSyntax
+    with OptionSyntax
+    with PartialFunctionLift
+    with StringSyntax
+    with TrySyntax

--- a/shared/src/main/scala/mouse/fboolean.scala
+++ b/shared/src/main/scala/mouse/fboolean.scala
@@ -1,0 +1,39 @@
+package mouse
+
+import cats.{Functor, Monad}
+
+trait FBooleanSyntax {
+  implicit final def FBooleanSyntaxMouse[F[_]](fBoolean: F[Boolean]): FBooleanOps[F] =
+    new FBooleanOps[F](fBoolean)
+}
+
+final class FBooleanOps[F[_]](private val fBoolean: F[Boolean]) extends AnyVal {
+
+  /**
+   * Transforms this `F[Boolean]` by negating the `Boolean`
+   */
+  def not(implicit F: Functor[F]): F[Boolean] =
+    F.map(fBoolean)(b => !b)
+
+  /**
+   * Behaves like `&&` but inside the `F` context.
+   *
+   * Wont evaluate `other` unless this evaluates to `true`
+   */
+  def andM(other: => F[Boolean])(implicit F: Monad[F]): F[Boolean] =
+    F.flatMap(fBoolean) {
+      case false => F.pure(false)
+      case true  => other
+    }
+
+  /**
+   * Behaves like `||` but inside the `F` context.
+   *
+   * Wont evaluate `other` unless this evaluates to `false`
+   */
+  def orM(other: => F[Boolean])(implicit F: Monad[F]): F[Boolean] =
+    F.flatMap(fBoolean) {
+      case true  => F.pure(true)
+      case false => other
+    }
+}

--- a/shared/src/main/scala/mouse/fboolean.scala
+++ b/shared/src/main/scala/mouse/fboolean.scala
@@ -20,7 +20,7 @@ final class FBooleanOps[F[_]](private val fBoolean: F[Boolean]) extends AnyVal {
    *
    * Wont evaluate `other` unless this evaluates to `true`
    */
-  def andM(other: => F[Boolean])(implicit F: Monad[F]): F[Boolean] =
+  def andM(other: => F[Boolean])(implicit F: FlatMap[F]): F[Boolean] =
     F.flatMap(fBoolean) {
       case false => F.pure(false)
       case true  => other
@@ -31,7 +31,7 @@ final class FBooleanOps[F[_]](private val fBoolean: F[Boolean]) extends AnyVal {
    *
    * Wont evaluate `other` unless this evaluates to `false`
    */
-  def orM(other: => F[Boolean])(implicit F: Monad[F]): F[Boolean] =
+  def orM(other: => F[Boolean])(implicit F: FlatMap[F]): F[Boolean] =
     F.flatMap(fBoolean) {
       case true  => F.pure(true)
       case false => other

--- a/shared/src/main/scala/mouse/fboolean.scala
+++ b/shared/src/main/scala/mouse/fboolean.scala
@@ -1,6 +1,6 @@
 package mouse
 
-import cats.{Functor, Monad}
+import cats.{Functor, FlatMap}
 
 trait FBooleanSyntax {
   implicit final def FBooleanSyntaxMouse[F[_]](fBoolean: F[Boolean]): FBooleanOps[F] =

--- a/shared/src/main/scala/mouse/fboolean.scala
+++ b/shared/src/main/scala/mouse/fboolean.scala
@@ -1,6 +1,6 @@
 package mouse
 
-import cats.{FlatMap, Functor}
+import cats.{Functor, Monad}
 
 trait FBooleanSyntax {
   implicit final def FBooleanSyntaxMouse[F[_]](fBoolean: F[Boolean]): FBooleanOps[F] =
@@ -20,7 +20,7 @@ final class FBooleanOps[F[_]](private val fBoolean: F[Boolean]) extends AnyVal {
    *
    * Wont evaluate `other` unless this evaluates to `true`
    */
-  def andM(other: => F[Boolean])(implicit F: FlatMap[F]): F[Boolean] =
+  def andM(other: => F[Boolean])(implicit F: Monad[F]): F[Boolean] =
     F.flatMap(fBoolean) {
       case false => F.pure(false)
       case true  => other
@@ -31,7 +31,7 @@ final class FBooleanOps[F[_]](private val fBoolean: F[Boolean]) extends AnyVal {
    *
    * Wont evaluate `other` unless this evaluates to `false`
    */
-  def orM(other: => F[Boolean])(implicit F: FlatMap[F]): F[Boolean] =
+  def orM(other: => F[Boolean])(implicit F: Monad[F]): F[Boolean] =
     F.flatMap(fBoolean) {
       case true  => F.pure(true)
       case false => other

--- a/shared/src/main/scala/mouse/fboolean.scala
+++ b/shared/src/main/scala/mouse/fboolean.scala
@@ -1,6 +1,6 @@
 package mouse
 
-import cats.{Functor, FlatMap}
+import cats.{FlatMap, Functor}
 
 trait FBooleanSyntax {
   implicit final def FBooleanSyntaxMouse[F[_]](fBoolean: F[Boolean]): FBooleanOps[F] =

--- a/shared/src/test/scala/mouse/FBooleanSyntaxTests.scala
+++ b/shared/src/test/scala/mouse/FBooleanSyntaxTests.scala
@@ -1,0 +1,56 @@
+package mouse
+
+import cats.{Eval, Id}
+
+class FBooleanSyntaxTests extends MouseSuite {
+  test("FBooleanSyntax.not") {
+    assertEquals(Id(true).not, Id(false))
+    assertEquals(Id(false).not, Id(true))
+  }
+
+  test("FBooleanSyntax.andM") {
+    // Boolean logic.
+    assertEquals(Id(true).andM(Id(true)), Id(true))
+    assertEquals(Id(true).andM(Id(false)), Id(false))
+    assertEquals(Id(false).andM(Id(true)), Id(false))
+    assertEquals(Id(false).andM(Id(false)), Id(false))
+
+    // Short-circuit.
+    var evalWasEvaluated = false
+    var functionWasCalled = false
+    def other = {
+      functionWasCalled = true
+      Eval.later {
+        evalWasEvaluated = true
+        true
+      }
+    }
+
+    Eval.now(false).andM(other)
+    assertEquals(evalWasEvaluated, false)
+    assertEquals(functionWasCalled, false)
+  }
+
+  test("FBooleanSyntax.orM") {
+    // Boolean logic.
+    assertEquals(Id(true).orM(Id(true)), Id(true))
+    assertEquals(Id(true).orM(Id(false)), Id(true))
+    assertEquals(Id(false).orM(Id(true)), Id(true))
+    assertEquals(Id(false).orM(Id(false)), Id(false))
+
+    // Short-circuit.
+    var evalWasEvaluated = false
+    var functionWasCalled = false
+    def other = {
+      functionWasCalled = true
+      Eval.later {
+        evalWasEvaluated = true
+        true
+      }
+    }
+
+    Eval.now(true).orM(other)
+    assertEquals(evalWasEvaluated, false)
+    assertEquals(functionWasCalled, false)
+  }
+}


### PR DESCRIPTION
Migrated from **cats**: https://github.com/typelevel/cats/pull/4114

IMHO these three operations are useful and relatively common enough that is good to have them, especially the `andM` & `orM` since they preserve the short-circuit behavior from traditional boolean operations.

Let me know what you all think and if the test / scaladoc are good.