### PR TITLE
Thin `README`

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ or otherwise improve the functional programming experience.
 
 ## Contributing
 
-Mouse is maintained by @benhutchison and @danicheg
+Mouse is maintained by @benhutchison and @danicheg.
 
 Issues and pull requests are welcome. Code contributions should be aligned with the above scope to be included, and include unit tests.
 See [contributing guide](./DEV.md) for more details.

--- a/README.md
+++ b/README.md
@@ -118,57 +118,6 @@ scala> val tupleLast = (1, 2, 4, 8).last
 tupleHead: Int = 8
 ```
 
-#### Release Notes
-
-Please see [Releases](https://github.com/typelevel/mouse/releases) for newer releases >= `1.0.0` (Mar 21)
-
-Version `0.26` (Dec 20) adds `applyIf` for Boolean and builds against Cats 2.3.0.
-
-Version `0.25` (Apr 20) adds Scalajs 1.x support.
-
-Version `0.24` (Dec 19) adds `valueOrPure` for Boolean and `parseUrl`/`parseUri` for String. Drops 2.11 support. Built against cats `2.1.0`.
-
-Version `0.23` (Aug 19) adds parsing of `BigInt` and `BigDecimal`. Built against cats `2.0.0-RC1`.
-
-Version `0.22` (June 19) is about support for Scala 2.13.0. Built against cats `2.0.0-M4`.
-
-Version `0.21` (May 19) is about support for Scala 2.13.0 RC1. Built against cats `2.0 M1`.
-
-Version `0.20` (Dec 18) adds syntax for Map and add support for Scala 2.13.0 M5. Built against cats `1.5.0`.
-
-Version `0.19` (Oct 18) adds syntax for F[A] and is built against cats `1.4.0`. Support for Scala 2.10 is removed in this release.
-
-Version `0.18` (Aug 18) adds PartialFunction lift to Either and is built against cats `1.2.0`
-
-Version `0.17` (Apr 18) is built against cats `1.1.0`
-
-Version `0.16` (Jan 18) is built against cats `1.0.1`
-
-Version `0.15` (Dec 17) is built against cats `1.0.0`
-
-Version `0.14` (Dec 17) include Int/Long/Double squared and is built against cats `1.0.0-RC2`
-
-Version `0.13` (Dec 17) include Int/Long/Double toByteArray and toBase64 operations and is built against cats `1.0.0-RC1`
-
-Version `0.12` (Nov 17) include Boolean Monoid operations and is built against cats `1.0.0-RC1`
-
-Version `0.11` (Oct 17) migrates to `org.typelevel` group and remains built against cats `1.0.0-MF`
-
-Version `0.10-MF` (Aug 17) is built against cats `1.0.0-MF`. It mainly supports compat testing for cats 1.0 release.
-
-Version `0.9` (Jun 17) is built against cats `0.9`, rename `either`->`toEither` on Try to align with 2.12 core changes.
-
-Version `0.8` (Jun 17) is built against cats `0.9`, `cata` and `either` on Try.
-
-Version `0.7` (Apr 17) is built against cats `0.9`, Boolean `fold`, Option `right` and `left`.
-
-Version `0.6` (Nov 16) is built against cats `0.8.1` and migrates `Xor` boolean syntax to `Either`.
-
-Version `0.5` (Aug 16) is built against cats `0.7.0` but otherwise unchanged.
-
-Version `0.4` (July 2016) includes a breaking package rename from `com.github.benhutchison.mouse` -> `mouse`. Rationale was
-to follow cats and other modern libs convention of short, convenient package names.
-
 ## Scope of Library
 
 - Provide enrichments to classes from the Scala standard library that convert to Cats datatypes,


### PR DESCRIPTION
1.0 version was released about 1 year ago. We should thin the readme for better readability, I suggest.