### PR TITLE
Add `F[TupleN]` syntax

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -40,7 +40,8 @@ lazy val cross = crossProject(JSPlatform, JVMPlatform)
         case _                         => Nil
       }
     },
-    mimaPreviousArtifacts ~= { _.filterNot(_.revision == "1.0.1") }
+    mimaPreviousArtifacts ~= { _.filterNot(_.revision == "1.0.1") },
+    Compile / sourceGenerators += (Compile / sourceManaged).map(Boilerplate.gen).taskValue
   )
   .jsSettings(
     crossScalaVersions := (ThisBuild / crossScalaVersions).value.filter(_.startsWith("2"))

--- a/js/src/main/scala/mouse/package.scala
+++ b/js/src/main/scala/mouse/package.scala
@@ -8,6 +8,7 @@ package object mouse extends MouseFunctions {
   object feither extends FEitherSyntax
   object fnested extends FNestedSyntax
   object foption extends FOptionSyntax
+  object ftuple extends FTupleSyntax
   object int extends IntSyntax
   object long extends LongSyntax
   object map extends MapSyntax

--- a/jvm/src/main/scala-2/src/main/scala/mouse/package.scala
+++ b/jvm/src/main/scala-2/src/main/scala/mouse/package.scala
@@ -8,6 +8,7 @@ package object mouse extends MouseFunctions {
   object feither extends FEitherSyntax
   object fnested extends FNestedSyntax
   object foption extends FOptionSyntax
+  object ftuple extends FTupleSyntax
   object int extends IntSyntax
   object long extends LongSyntax
   object map extends MapSyntax

--- a/jvm/src/main/scala-3/src/main/scala/mouse/package.scala
+++ b/jvm/src/main/scala-3/src/main/scala/mouse/package.scala
@@ -8,6 +8,7 @@ package object mouse extends MouseFunctions {
   object feither extends FEitherSyntax
   object fnested extends FNestedSyntax
   object foption extends FOptionSyntax
+  object ftuple extends FTupleSyntax
   object int extends IntSyntax
   object long extends LongSyntax
   object map extends MapSyntax

--- a/project/Boilerplate.scala
+++ b/project/Boilerplate.scala
@@ -1,5 +1,7 @@
 import sbt._
+
 import scala.annotation.tailrec
+import scala.collection.immutable
 
 /**
  * Copied, with some modifications, from https://github.com/milessabin/shapeless/blob/main/project/Boilerplate.scala
@@ -27,7 +29,7 @@ object Boilerplate {
 
   val templates: Seq[Template] = Seq(GenFTupleNSyntax)
 
-  val header =
+  val header: String =
     """// auto-generated boilerplate by /project/Boilerplate.scala
       |package mouse
       |""".stripMargin
@@ -42,57 +44,11 @@ object Boilerplate {
       tgtFile
     }
 
-  val maxArity = 22
+  val maxArity: Int = 22
 
   final class TemplateVals(val arity: Int) {
-    val synTypes = (0 until arity).map(n => s"A$n")
-    val synVals = (0 until arity).map(n => s"a$n")
-    val synTypedVals = synVals.zip(synTypes).map { case (v, t) => v + ":" + t }
-    val `A..N` = synTypes.mkString(", ")
-    val `a..n` = synVals.mkString(", ")
-    val `_.._` = Seq.fill(arity)("_").mkString(", ")
-    val `(A..N)` = if (arity == 1) "Tuple1[A0]" else synTypes.mkString("(", ", ", ")")
-    val `(_.._)` = if (arity == 1) "Tuple1[_]" else Seq.fill(arity)("_").mkString("(", ", ", ")")
-    val `(a..n)` = if (arity == 1) "Tuple1(a)" else synVals.mkString("(", ", ", ")")
-    val `a:A..n:N` = synTypedVals.mkString(", ")
-
-    val `A..(N - 1)` = (0 until (arity - 1)).map(n => s"A$n")
-    val `A..(N - 2)` = (0 until (arity - 2)).map(n => s"A$n")
-    val `A0, A(N - 1)` = if (arity <= 1) "" else `A..(N - 1)`.mkString(", ")
-    val `A0, A(N - 2)` = if (arity <= 2) "" else `A..(N - 2)`.mkString("", ", ", ", ")
-    val `[A0, A(N - 2)]` = if (arity <= 2) "" else `A..(N - 2)`.mkString("[", ", ", "]")
-    val `(A..N - 2, *, *)` =
-      if (arity <= 2) "(*, *)"
-      else `A..(N - 2)`.mkString("(", ", ", ", *, *)")
-    val `a..(n - 1)` = (0 until (arity - 1)).map(n => s"a$n")
-    val `fa._1..fa._(n - 2)` =
-      if (arity <= 2) "" else (0 until (arity - 2)).map(n => s"fa._${n + 1}").mkString("", ", ", ", ")
-    val `pure(fa._1..(n - 2))` =
-      if (arity <= 2) "" else (0 until (arity - 2)).map(n => s"G.pure(fa._${n + 1})").mkString("", ", ", ", ")
-    val `a0, a(n - 1)` = if (arity <= 1) "" else `a..(n - 1)`.mkString(", ")
-    val `[A0, A(N - 1)]` = if (arity <= 1) "" else `A..(N - 1)`.mkString("[", ", ", "]")
-    val `(A0, A(N - 1))` =
-      if (arity == 1) "Tuple1[A0]"
-      else if (arity == 2) "A0"
-      else `A..(N - 1)`.mkString("(", ", ", ")")
-    val `(A..N - 1, *)` =
-      if (arity == 1) "Tuple1"
-      else `A..(N - 1)`.mkString("(", ", ", ", *)")
-    val `(fa._1..(n - 1))` =
-      if (arity <= 1) "Tuple1.apply" else (0 until (arity - 1)).map(n => s"fa._${n + 1}").mkString("(", ", ", ", _)")
-
-    def `A0, A(N - 1)&`(a: String): String =
-      if (arity <= 1) s"Tuple1[$a]" else `A..(N - 1)`.mkString("(", ", ", s", $a)")
-
-    def `fa._1..(n - 1) & `(a: String): String =
-      if (arity <= 1) s"Tuple1($a)" else (0 until (arity - 1)).map(n => s"fa._${n + 1}").mkString("(", ", ", s", $a)")
-
-    def `constraints A..N`(c: String): String = synTypes.map(tpe => s"$tpe: $c[$tpe]").mkString("(implicit ", ", ", ")")
-
-    def `constraints A..(N-1)`(c: String): String =
-      if (arity <= 1) "" else `A..(N - 1)`.map(tpe => s"$tpe: $c[$tpe]").mkString("(implicit ", ", ", ")")
-
-    def `parameters A..(N-1)`(c: String): String = `A..(N - 1)`.map(tpe => s"$tpe: $c[$tpe]").mkString(", ")
+    val synTypes: immutable.Seq[String] = (0 until arity).map(n => s"A$n")
+    val `A..N`: String = synTypes.mkString(", ")
   }
 
   trait Template {

--- a/project/Boilerplate.scala
+++ b/project/Boilerplate.scala
@@ -1,0 +1,126 @@
+import sbt._
+import scala.annotation.tailrec
+
+/**
+ * Copied, with some modifications, from https://github.com/milessabin/shapeless/blob/main/project/Boilerplate.scala
+ *
+ * Generate a range of boilerplate classes, those offering alternatives with 0-22 params and would be tedious to craft
+ * by hand
+ *
+ * @author
+ *   Miles Sabin
+ * @author
+ *   Kevin Wright
+ */
+object Boilerplate {
+
+  import scala.StringContext._
+
+  implicit final class BlockHelper(private val sc: StringContext) extends AnyVal {
+    def block(args: Any*): String = {
+      val interpolated = sc.standardInterpolator(treatEscapes, args)
+      val rawLines = interpolated.split('\n')
+      val trimmedLines = rawLines.map(_.dropWhile(_.isWhitespace))
+      trimmedLines.mkString("\n")
+    }
+  }
+
+  val templates: Seq[Template] = Seq(GenFTupleNSyntax)
+
+  val header =
+    """// auto-generated boilerplate by /project/Boilerplate.scala
+      |package mouse
+      |""".stripMargin
+
+  /**
+   * Returns a seq of the generated files. As a side-effect, it actually generates them...
+   */
+  def gen(dir: File) =
+    for (t <- templates) yield {
+      val tgtFile = t.filename(dir)
+      IO.write(tgtFile, t.body)
+      tgtFile
+    }
+
+  val maxArity = 22
+
+  final class TemplateVals(val arity: Int) {
+    val synTypes = (0 until arity).map(n => s"A$n")
+    val synVals = (0 until arity).map(n => s"a$n")
+    val synTypedVals = synVals.zip(synTypes).map { case (v, t) => v + ":" + t }
+    val `A..N` = synTypes.mkString(", ")
+    val `a..n` = synVals.mkString(", ")
+    val `_.._` = Seq.fill(arity)("_").mkString(", ")
+    val `(A..N)` = if (arity == 1) "Tuple1[A0]" else synTypes.mkString("(", ", ", ")")
+    val `(_.._)` = if (arity == 1) "Tuple1[_]" else Seq.fill(arity)("_").mkString("(", ", ", ")")
+    val `(a..n)` = if (arity == 1) "Tuple1(a)" else synVals.mkString("(", ", ", ")")
+    val `a:A..n:N` = synTypedVals.mkString(", ")
+
+    val `A..(N - 1)` = (0 until (arity - 1)).map(n => s"A$n")
+    val `A..(N - 2)` = (0 until (arity - 2)).map(n => s"A$n")
+    val `A0, A(N - 1)` = if (arity <= 1) "" else `A..(N - 1)`.mkString(", ")
+    val `A0, A(N - 2)` = if (arity <= 2) "" else `A..(N - 2)`.mkString("", ", ", ", ")
+    val `[A0, A(N - 2)]` = if (arity <= 2) "" else `A..(N - 2)`.mkString("[", ", ", "]")
+    val `(A..N - 2, *, *)` =
+      if (arity <= 2) "(*, *)"
+      else `A..(N - 2)`.mkString("(", ", ", ", *, *)")
+    val `a..(n - 1)` = (0 until (arity - 1)).map(n => s"a$n")
+    val `fa._1..fa._(n - 2)` =
+      if (arity <= 2) "" else (0 until (arity - 2)).map(n => s"fa._${n + 1}").mkString("", ", ", ", ")
+    val `pure(fa._1..(n - 2))` =
+      if (arity <= 2) "" else (0 until (arity - 2)).map(n => s"G.pure(fa._${n + 1})").mkString("", ", ", ", ")
+    val `a0, a(n - 1)` = if (arity <= 1) "" else `a..(n - 1)`.mkString(", ")
+    val `[A0, A(N - 1)]` = if (arity <= 1) "" else `A..(N - 1)`.mkString("[", ", ", "]")
+    val `(A0, A(N - 1))` =
+      if (arity == 1) "Tuple1[A0]"
+      else if (arity == 2) "A0"
+      else `A..(N - 1)`.mkString("(", ", ", ")")
+    val `(A..N - 1, *)` =
+      if (arity == 1) "Tuple1"
+      else `A..(N - 1)`.mkString("(", ", ", ", *)")
+    val `(fa._1..(n - 1))` =
+      if (arity <= 1) "Tuple1.apply" else (0 until (arity - 1)).map(n => s"fa._${n + 1}").mkString("(", ", ", ", _)")
+
+    def `A0, A(N - 1)&`(a: String): String =
+      if (arity <= 1) s"Tuple1[$a]" else `A..(N - 1)`.mkString("(", ", ", s", $a)")
+
+    def `fa._1..(n - 1) & `(a: String): String =
+      if (arity <= 1) s"Tuple1($a)" else (0 until (arity - 1)).map(n => s"fa._${n + 1}").mkString("(", ", ", s", $a)")
+
+    def `constraints A..N`(c: String): String = synTypes.map(tpe => s"$tpe: $c[$tpe]").mkString("(implicit ", ", ", ")")
+
+    def `constraints A..(N-1)`(c: String): String =
+      if (arity <= 1) "" else `A..(N - 1)`.map(tpe => s"$tpe: $c[$tpe]").mkString("(implicit ", ", ", ")")
+
+    def `parameters A..(N-1)`(c: String): String = `A..(N - 1)`.map(tpe => s"$tpe: $c[$tpe]").mkString(", ")
+  }
+
+  trait Template {
+    def filename(root: File): File
+
+    def content(tv: TemplateVals): String
+
+    def range = 1 to maxArity
+
+    def body: String = {
+      @tailrec
+      def expandInstances(contents: IndexedSeq[Array[String]], acc: Array[String] = Array.empty): Array[String] =
+        if (!contents.exists(_.exists(_.startsWith("-"))))
+          acc.map(_.tail)
+        else {
+          val pre = contents.head.takeWhile(_.startsWith("|"))
+          val instances = contents.flatMap(_.dropWhile(_.startsWith("|")).takeWhile(_.startsWith("-")))
+          val next = contents.map(_.dropWhile(_.startsWith("|")).dropWhile(_.startsWith("-")))
+          expandInstances(next, acc ++ pre ++ instances)
+        }
+
+      val rawContents = range.map { n =>
+        content(new TemplateVals(n)).split('\n').filterNot(_.isEmpty)
+      }
+      val headerLines = header.split('\n')
+      val instances = expandInstances(rawContents)
+      val footerLines = rawContents.head.reverse.takeWhile(_.startsWith("|")).map(_.tail).reverse
+      (headerLines ++ instances ++ footerLines).mkString("\n")
+    }
+  }
+}

--- a/project/GenFTupleNSyntax.scala
+++ b/project/GenFTupleNSyntax.scala
@@ -1,0 +1,42 @@
+import sbt._
+
+import Boilerplate._
+import Boilerplate.{Template, TemplateVals}
+import sbt.File
+
+object GenFTupleNSyntax extends Template {
+  // we generate syntax for Tuple3..22 because already there is [[cats.syntax.FunctorTuple2Ops]].
+  override def range = 3 to maxArity
+  override def filename(root: sbt.File): File =
+    root / "mouse" / "FTupleNSyntax.scala"
+
+  override def content(tv: TemplateVals): String = {
+    import tv._
+
+    val generatedFunctions: String =
+      (1 to arity)
+        .map { n =>
+          s"""
+          -  /**
+          -   * Lifts [[Tuple$arity._$n]] into `F[_]`.
+          -   */
+          -  def _${n}F(implicit F: Functor[F]): F[A${n - 1}] = F.map(ftuple)(_._$n)
+          -
+          """
+        }
+        .mkString("\n")
+
+    block"""
+    |
+    |import cats.Functor
+    |
+    |trait FTupleNSyntax {
+      -  implicit final def mouseSyntaxFTuple${arity}Ops[F[_], ${`A..N`}](ftuple: F[(${`A..N`})]): FTuple${arity}Ops[F, ${`A..N`}] = new FTuple${arity}Ops[F, ${`A..N`}](ftuple)
+      -
+      -  private[mouse] final class FTuple${arity}Ops[F[_], ${`A..N`}](ftuple: F[(${`A..N`})]) extends Serializable {
+           $generatedFunctions
+      -  }
+      -
+    |}"""
+  }
+}

--- a/shared/src/main/scala-2/src/main/scala/mouse/all.scala
+++ b/shared/src/main/scala-2/src/main/scala/mouse/all.scala
@@ -9,6 +9,7 @@ trait AllSharedSyntax
     with FEitherSyntax
     with FNestedSyntax
     with FOptionSyntax
+    with FTupleSyntax
     with IntSyntax
     with LongSyntax
     with MapSyntax

--- a/shared/src/main/scala-3/src/main/scala/mouse/all.scala
+++ b/shared/src/main/scala-3/src/main/scala/mouse/all.scala
@@ -9,6 +9,7 @@ trait AllSharedSyntax
     with FEitherSyntax
     with FNestedSyntax
     with FOptionSyntax
+    with FTupleSyntax
     with IntSyntax
     with LongSyntax
     with MapSyntax

--- a/shared/src/main/scala/mouse/ftuple.scala
+++ b/shared/src/main/scala/mouse/ftuple.scala
@@ -1,0 +1,5 @@
+package mouse
+
+trait FTupleSyntax extends FTupleNSyntax
+
+object FTupleSyntax

--- a/shared/src/test/scala/mouse/FTupleNSyntaxSuite.scala
+++ b/shared/src/test/scala/mouse/FTupleNSyntaxSuite.scala
@@ -1,0 +1,386 @@
+package mouse
+
+import org.scalacheck.Prop._
+
+class FTupleNSyntaxSuite extends MouseSuite {
+  test("_1F, _2F, _3F works for Tuple3") {
+    forAll { (l: List[(Int, Int, Int)]) =>
+      assertEquals(l._1F, l.map(_._1))
+      assertEquals(l._2F, l.map(_._2))
+      assertEquals(l._3F, l.map(_._3))
+    }
+  }
+
+  test("_1F, _2F, _3F, _4F works for Tuple4") {
+    forAll { (l: List[(Int, Int, Int, Int)]) =>
+      assertEquals(l._1F, l.map(_._1))
+      assertEquals(l._2F, l.map(_._2))
+      assertEquals(l._3F, l.map(_._3))
+      assertEquals(l._4F, l.map(_._4))
+    }
+  }
+
+  test("_1F, _2F, _3F, _4F, _5F works for Tuple5") {
+    forAll { (l: List[(Int, Int, Int, Int, Int)]) =>
+      assertEquals(l._1F, l.map(_._1))
+      assertEquals(l._2F, l.map(_._2))
+      assertEquals(l._3F, l.map(_._3))
+      assertEquals(l._4F, l.map(_._4))
+      assertEquals(l._5F, l.map(_._5))
+    }
+  }
+
+  test("_1F, _2F, _3F, _4F, _5F, _6F works for Tuple6") {
+    forAll { (l: List[(Int, Int, Int, Int, Int, Int)]) =>
+      assertEquals(l._1F, l.map(_._1))
+      assertEquals(l._2F, l.map(_._2))
+      assertEquals(l._3F, l.map(_._3))
+      assertEquals(l._4F, l.map(_._4))
+      assertEquals(l._5F, l.map(_._5))
+      assertEquals(l._6F, l.map(_._6))
+    }
+  }
+
+  test("_1F, _2F, _3F, _4F, _5F, _6F works for Tuple6") {
+    forAll { (l: List[(Int, Int, Int, Int, Int, Int)]) =>
+      assertEquals(l._1F, l.map(_._1))
+      assertEquals(l._2F, l.map(_._2))
+      assertEquals(l._3F, l.map(_._3))
+      assertEquals(l._4F, l.map(_._4))
+      assertEquals(l._5F, l.map(_._5))
+      assertEquals(l._6F, l.map(_._6))
+    }
+  }
+
+  test("_1F, _2F, _3F, _4F, _5F, _6F, _7F works for Tuple7") {
+    forAll { (l: List[(Int, Int, Int, Int, Int, Int, Int)]) =>
+      assertEquals(l._1F, l.map(_._1))
+      assertEquals(l._2F, l.map(_._2))
+      assertEquals(l._3F, l.map(_._3))
+      assertEquals(l._4F, l.map(_._4))
+      assertEquals(l._5F, l.map(_._5))
+      assertEquals(l._6F, l.map(_._6))
+      assertEquals(l._7F, l.map(_._7))
+    }
+  }
+
+  test("_1F, _2F, _3F, _4F, _5F, _6F, _7F, 8F works for Tuple8") {
+    forAll { (l: List[(Int, Int, Int, Int, Int, Int, Int, Int)]) =>
+      assertEquals(l._1F, l.map(_._1))
+      assertEquals(l._2F, l.map(_._2))
+      assertEquals(l._3F, l.map(_._3))
+      assertEquals(l._4F, l.map(_._4))
+      assertEquals(l._5F, l.map(_._5))
+      assertEquals(l._6F, l.map(_._6))
+      assertEquals(l._7F, l.map(_._7))
+      assertEquals(l._8F, l.map(_._8))
+    }
+  }
+
+  test("_1F, _2F, _3F, _4F, _5F, _6F, _7F, _8F, _9F works for Tuple9") {
+    forAll { (l: List[(Int, Int, Int, Int, Int, Int, Int, Int, Int)]) =>
+      assertEquals(l._1F, l.map(_._1))
+      assertEquals(l._2F, l.map(_._2))
+      assertEquals(l._3F, l.map(_._3))
+      assertEquals(l._4F, l.map(_._4))
+      assertEquals(l._5F, l.map(_._5))
+      assertEquals(l._6F, l.map(_._6))
+      assertEquals(l._7F, l.map(_._7))
+      assertEquals(l._8F, l.map(_._8))
+      assertEquals(l._9F, l.map(_._9))
+    }
+  }
+
+  test("_1F, _2F, _3F, _4F, _5F, _6F, _7F, _8F, _9F, _10F works for Tuple10") {
+    forAll { (l: List[(Int, Int, Int, Int, Int, Int, Int, Int, Int, Int)]) =>
+      assertEquals(l._1F, l.map(_._1))
+      assertEquals(l._2F, l.map(_._2))
+      assertEquals(l._3F, l.map(_._3))
+      assertEquals(l._4F, l.map(_._4))
+      assertEquals(l._5F, l.map(_._5))
+      assertEquals(l._6F, l.map(_._6))
+      assertEquals(l._7F, l.map(_._7))
+      assertEquals(l._8F, l.map(_._8))
+      assertEquals(l._9F, l.map(_._9))
+      assertEquals(l._10F, l.map(_._10))
+    }
+  }
+
+  test("_1F, _2F, _3F, _4F, _5F, _6F, _7F, _8F, _9F, _10F, _11F works for Tuple11") {
+    forAll { (l: List[(Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int)]) =>
+      assertEquals(l._1F, l.map(_._1))
+      assertEquals(l._2F, l.map(_._2))
+      assertEquals(l._3F, l.map(_._3))
+      assertEquals(l._4F, l.map(_._4))
+      assertEquals(l._5F, l.map(_._5))
+      assertEquals(l._6F, l.map(_._6))
+      assertEquals(l._7F, l.map(_._7))
+      assertEquals(l._8F, l.map(_._8))
+      assertEquals(l._9F, l.map(_._9))
+      assertEquals(l._10F, l.map(_._10))
+      assertEquals(l._11F, l.map(_._11))
+    }
+  }
+
+  test("_1F, _2F, _3F, _4F, _5F, _6F, _7F, _8F, _9F, _10F, _11F, _12F works for Tuple12") {
+    forAll { (l: List[(Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int)]) =>
+      assertEquals(l._1F, l.map(_._1))
+      assertEquals(l._2F, l.map(_._2))
+      assertEquals(l._3F, l.map(_._3))
+      assertEquals(l._4F, l.map(_._4))
+      assertEquals(l._5F, l.map(_._5))
+      assertEquals(l._6F, l.map(_._6))
+      assertEquals(l._7F, l.map(_._7))
+      assertEquals(l._8F, l.map(_._8))
+      assertEquals(l._9F, l.map(_._9))
+      assertEquals(l._10F, l.map(_._10))
+      assertEquals(l._11F, l.map(_._11))
+      assertEquals(l._12F, l.map(_._12))
+    }
+  }
+
+  test("_1F, _2F, _3F, _4F, _5F, _6F, _7F, _8F, _9F, _10F, _11F, _12F, _13F works for Tuple13") {
+    forAll { (l: List[(Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int)]) =>
+      assertEquals(l._1F, l.map(_._1))
+      assertEquals(l._2F, l.map(_._2))
+      assertEquals(l._3F, l.map(_._3))
+      assertEquals(l._4F, l.map(_._4))
+      assertEquals(l._5F, l.map(_._5))
+      assertEquals(l._6F, l.map(_._6))
+      assertEquals(l._7F, l.map(_._7))
+      assertEquals(l._8F, l.map(_._8))
+      assertEquals(l._9F, l.map(_._9))
+      assertEquals(l._10F, l.map(_._10))
+      assertEquals(l._11F, l.map(_._11))
+      assertEquals(l._12F, l.map(_._12))
+      assertEquals(l._13F, l.map(_._13))
+    }
+  }
+
+  test("_1F, _2F, _3F, _4F, _5F, _6F, _7F, _8F, _9F, _10F, _11F, _12F, _13F, _14F works for Tuple14") {
+    forAll { (l: List[(Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int)]) =>
+      assertEquals(l._1F, l.map(_._1))
+      assertEquals(l._2F, l.map(_._2))
+      assertEquals(l._3F, l.map(_._3))
+      assertEquals(l._4F, l.map(_._4))
+      assertEquals(l._5F, l.map(_._5))
+      assertEquals(l._6F, l.map(_._6))
+      assertEquals(l._7F, l.map(_._7))
+      assertEquals(l._8F, l.map(_._8))
+      assertEquals(l._9F, l.map(_._9))
+      assertEquals(l._10F, l.map(_._10))
+      assertEquals(l._11F, l.map(_._11))
+      assertEquals(l._12F, l.map(_._12))
+      assertEquals(l._13F, l.map(_._13))
+      assertEquals(l._14F, l.map(_._14))
+    }
+  }
+
+  test("_1F, _2F, _3F, _4F, _5F, _6F, _7F, _8F, _9F, _10F, _11F, _12F, _13F, _14F, _15F works for Tuple15") {
+    forAll { (l: List[(Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int)]) =>
+      assertEquals(l._1F, l.map(_._1))
+      assertEquals(l._2F, l.map(_._2))
+      assertEquals(l._3F, l.map(_._3))
+      assertEquals(l._4F, l.map(_._4))
+      assertEquals(l._5F, l.map(_._5))
+      assertEquals(l._6F, l.map(_._6))
+      assertEquals(l._7F, l.map(_._7))
+      assertEquals(l._8F, l.map(_._8))
+      assertEquals(l._9F, l.map(_._9))
+      assertEquals(l._10F, l.map(_._10))
+      assertEquals(l._11F, l.map(_._11))
+      assertEquals(l._12F, l.map(_._12))
+      assertEquals(l._13F, l.map(_._13))
+      assertEquals(l._14F, l.map(_._14))
+      assertEquals(l._15F, l.map(_._15))
+    }
+  }
+
+  test("_1F, _2F, _3F, _4F, _5F, _6F, _7F, _8F, _9F, _10F, _11F, _12F, _13F, _14F, _15F, _16F works for Tuple16") {
+    forAll { (l: List[(Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int)]) =>
+      assertEquals(l._1F, l.map(_._1))
+      assertEquals(l._2F, l.map(_._2))
+      assertEquals(l._3F, l.map(_._3))
+      assertEquals(l._4F, l.map(_._4))
+      assertEquals(l._5F, l.map(_._5))
+      assertEquals(l._6F, l.map(_._6))
+      assertEquals(l._7F, l.map(_._7))
+      assertEquals(l._8F, l.map(_._8))
+      assertEquals(l._9F, l.map(_._9))
+      assertEquals(l._10F, l.map(_._10))
+      assertEquals(l._11F, l.map(_._11))
+      assertEquals(l._12F, l.map(_._12))
+      assertEquals(l._13F, l.map(_._13))
+      assertEquals(l._14F, l.map(_._14))
+      assertEquals(l._15F, l.map(_._15))
+      assertEquals(l._16F, l.map(_._16))
+    }
+  }
+
+  test(
+    "_1F, _2F, _3F, _4F, _5F, _6F, _7F, _8F, _9F, _10F, _11F, _12F, _13F, _14F, _15F, _16F, _17F works for Tuple17"
+  ) {
+    forAll { (l: List[(Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int)]) =>
+      assertEquals(l._1F, l.map(_._1))
+      assertEquals(l._2F, l.map(_._2))
+      assertEquals(l._3F, l.map(_._3))
+      assertEquals(l._4F, l.map(_._4))
+      assertEquals(l._5F, l.map(_._5))
+      assertEquals(l._6F, l.map(_._6))
+      assertEquals(l._7F, l.map(_._7))
+      assertEquals(l._8F, l.map(_._8))
+      assertEquals(l._9F, l.map(_._9))
+      assertEquals(l._10F, l.map(_._10))
+      assertEquals(l._11F, l.map(_._11))
+      assertEquals(l._12F, l.map(_._12))
+      assertEquals(l._13F, l.map(_._13))
+      assertEquals(l._14F, l.map(_._14))
+      assertEquals(l._15F, l.map(_._15))
+      assertEquals(l._16F, l.map(_._16))
+      assertEquals(l._17F, l.map(_._17))
+    }
+  }
+
+  test(
+    "_1F, _2F, _3F, _4F, _5F, _6F, _7F, _8F, _9F, _10F, _11F, _12F, _13F, _14F, _15F, _16F, _17F, _18F works for Tuple18"
+  ) {
+    forAll { (l: List[(Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int)]) =>
+      assertEquals(l._1F, l.map(_._1))
+      assertEquals(l._2F, l.map(_._2))
+      assertEquals(l._3F, l.map(_._3))
+      assertEquals(l._4F, l.map(_._4))
+      assertEquals(l._5F, l.map(_._5))
+      assertEquals(l._6F, l.map(_._6))
+      assertEquals(l._7F, l.map(_._7))
+      assertEquals(l._8F, l.map(_._8))
+      assertEquals(l._9F, l.map(_._9))
+      assertEquals(l._10F, l.map(_._10))
+      assertEquals(l._11F, l.map(_._11))
+      assertEquals(l._12F, l.map(_._12))
+      assertEquals(l._13F, l.map(_._13))
+      assertEquals(l._14F, l.map(_._14))
+      assertEquals(l._15F, l.map(_._15))
+      assertEquals(l._16F, l.map(_._16))
+      assertEquals(l._17F, l.map(_._17))
+      assertEquals(l._18F, l.map(_._18))
+    }
+  }
+
+  test(
+    "_1F, _2F, _3F, _4F, _5F, _6F, _7F, _8F, _9F, _10F, _11F, _12F, _13F, _14F, _15F, _16F, _17F, _18F, _19F works for Tuple19"
+  ) {
+    forAll {
+      (l: List[(Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int)]) =>
+        assertEquals(l._1F, l.map(_._1))
+        assertEquals(l._2F, l.map(_._2))
+        assertEquals(l._3F, l.map(_._3))
+        assertEquals(l._4F, l.map(_._4))
+        assertEquals(l._5F, l.map(_._5))
+        assertEquals(l._6F, l.map(_._6))
+        assertEquals(l._7F, l.map(_._7))
+        assertEquals(l._8F, l.map(_._8))
+        assertEquals(l._9F, l.map(_._9))
+        assertEquals(l._10F, l.map(_._10))
+        assertEquals(l._11F, l.map(_._11))
+        assertEquals(l._12F, l.map(_._12))
+        assertEquals(l._13F, l.map(_._13))
+        assertEquals(l._14F, l.map(_._14))
+        assertEquals(l._15F, l.map(_._15))
+        assertEquals(l._16F, l.map(_._16))
+        assertEquals(l._17F, l.map(_._17))
+        assertEquals(l._18F, l.map(_._18))
+        assertEquals(l._19F, l.map(_._19))
+    }
+  }
+
+  test(
+    "_1F, _2F, _3F, _4F, _5F, _6F, _7F, _8F, _9F, _10F, _11F, _12F, _13F, _14F, _15F, _16F, _17F, _18F, _19F, _20F works for Tuple20"
+  ) {
+    forAll {
+      (l: List[(Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int)]) =>
+        assertEquals(l._1F, l.map(_._1))
+        assertEquals(l._2F, l.map(_._2))
+        assertEquals(l._3F, l.map(_._3))
+        assertEquals(l._4F, l.map(_._4))
+        assertEquals(l._5F, l.map(_._5))
+        assertEquals(l._6F, l.map(_._6))
+        assertEquals(l._7F, l.map(_._7))
+        assertEquals(l._8F, l.map(_._8))
+        assertEquals(l._9F, l.map(_._9))
+        assertEquals(l._10F, l.map(_._10))
+        assertEquals(l._11F, l.map(_._11))
+        assertEquals(l._12F, l.map(_._12))
+        assertEquals(l._13F, l.map(_._13))
+        assertEquals(l._14F, l.map(_._14))
+        assertEquals(l._15F, l.map(_._15))
+        assertEquals(l._16F, l.map(_._16))
+        assertEquals(l._17F, l.map(_._17))
+        assertEquals(l._18F, l.map(_._18))
+        assertEquals(l._19F, l.map(_._19))
+        assertEquals(l._20F, l.map(_._20))
+    }
+  }
+
+  test(
+    "_1F, _2F, _3F, _4F, _5F, _6F, _7F, _8F, _9F, _10F, _11F, _12F, _13F, _14F, _15F, _16F, _17F, _18F, _19F, _20F, _21F works for Tuple21"
+  ) {
+    forAll {
+      (l: List[
+        (Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int)
+      ]) =>
+        assertEquals(l._1F, l.map(_._1))
+        assertEquals(l._2F, l.map(_._2))
+        assertEquals(l._3F, l.map(_._3))
+        assertEquals(l._4F, l.map(_._4))
+        assertEquals(l._5F, l.map(_._5))
+        assertEquals(l._6F, l.map(_._6))
+        assertEquals(l._7F, l.map(_._7))
+        assertEquals(l._8F, l.map(_._8))
+        assertEquals(l._9F, l.map(_._9))
+        assertEquals(l._10F, l.map(_._10))
+        assertEquals(l._11F, l.map(_._11))
+        assertEquals(l._12F, l.map(_._12))
+        assertEquals(l._13F, l.map(_._13))
+        assertEquals(l._14F, l.map(_._14))
+        assertEquals(l._15F, l.map(_._15))
+        assertEquals(l._16F, l.map(_._16))
+        assertEquals(l._17F, l.map(_._17))
+        assertEquals(l._18F, l.map(_._18))
+        assertEquals(l._19F, l.map(_._19))
+        assertEquals(l._20F, l.map(_._20))
+        assertEquals(l._21F, l.map(_._21))
+    }
+  }
+
+  test(
+    "_1F, _2F, _3F, _4F, _5F, _6F, _7F, _8F, _9F, _10F, _11F, _12F, _13F, _14F, _15F, _16F, _17F, _18F, _19F, _20F, _21F, _22F works for Tuple22"
+  ) {
+    forAll {
+      (l: List[
+        (Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int)
+      ]) =>
+        assertEquals(l._1F, l.map(_._1))
+        assertEquals(l._2F, l.map(_._2))
+        assertEquals(l._3F, l.map(_._3))
+        assertEquals(l._4F, l.map(_._4))
+        assertEquals(l._5F, l.map(_._5))
+        assertEquals(l._6F, l.map(_._6))
+        assertEquals(l._7F, l.map(_._7))
+        assertEquals(l._8F, l.map(_._8))
+        assertEquals(l._9F, l.map(_._9))
+        assertEquals(l._10F, l.map(_._10))
+        assertEquals(l._11F, l.map(_._11))
+        assertEquals(l._12F, l.map(_._12))
+        assertEquals(l._13F, l.map(_._13))
+        assertEquals(l._14F, l.map(_._14))
+        assertEquals(l._15F, l.map(_._15))
+        assertEquals(l._16F, l.map(_._16))
+        assertEquals(l._17F, l.map(_._17))
+        assertEquals(l._18F, l.map(_._18))
+        assertEquals(l._19F, l.map(_._19))
+        assertEquals(l._20F, l.map(_._20))
+        assertEquals(l._21F, l.map(_._21))
+        assertEquals(l._22F, l.map(_._22))
+    }
+  }
+}


### PR DESCRIPTION
This migrated from https://github.com/typelevel/cats/pull/4125.
There is no syntax for Tuple2 because of `cats.syntax.FunctorTuple2Ops`.
At this point, `cats.syntax` is a kinda monolith that probably wouldn't be changed/extended in foreseeable future. So, Mouse to the rescue :)