### PR TITLE
Add missing docs for `F[TupleN]` syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Mouse includes enrichments for:
 - [F\[Option\[A\]\]](./shared/src/main/scala/mouse/foption.scala)
 - [F\[G\[A\]\]](./shared/src/main/scala/mouse/fnested.scala)
 - [F\[G\[H\[A\]\]\]](./shared/src/main/scala/mouse/fnested.scala)
+- [F\[TupleN\]](./shared/src/main/scala/mouse/ftuple.scala)
 - [Int](./shared/src/main/scala/mouse/int.scala)
 - [Long](./shared/src/main/scala/mouse/long.scala)
 - [Map](./shared/src/main/scala/mouse/map.scala)

--- a/docs/index.md
+++ b/docs/index.md
@@ -33,6 +33,7 @@ Mouse includes enrichments for:
 - [F\[Option\[A\]\]](https://www.javadoc.io/doc/org.typelevel/mouse_2.13/latest/mouse/FOptionOps.html)
 - [F\[G\[A\]\]](https://www.javadoc.io/doc/org.typelevel/mouse_2.13/latest/mouse/FNested2SyntaxOps.html)
 - [F\[G\[H\[A\]\]\]](https://www.javadoc.io/doc/org.typelevel/mouse_2.13/latest/mouse/FNested3SyntaxOps.html)
+- [F\[TupleN\]](https://www.javadoc.io/doc/org.typelevel/mouse_2.13/latest/mouse/FTupleNSyntax.html)
 - [Int](https://www.javadoc.io/doc/org.typelevel/mouse_2.13/latest/mouse/IntOps.html)
 - [Long](https://www.javadoc.io/doc/org.typelevel/mouse_2.13/latest/mouse/LongOps.html)
 - [Map\[K, V\]](https://www.javadoc.io/doc/org.typelevel/mouse_2.13/latest/mouse/MapOps.html)


### PR DESCRIPTION
Actually, this adds a few links about the `F[TupleN]` syntax. But it's better than nothing, I believe.