### PR TITLE
Add validated and validatedNec to boolean

### DIFF
--- a/shared/src/main/scala/mouse/boolean.scala
+++ b/shared/src/main/scala/mouse/boolean.scala
@@ -1,6 +1,6 @@
 package mouse
 
-import cats.data.{EitherNel, NonEmptyList, Validated, ValidatedNel}
+import cats.data.{EitherNel, NonEmptyList, Validated, ValidatedNec, ValidatedNel}
 import cats.{Applicative, ApplicativeError, Monoid}
 import mouse.BooleanSyntax.LiftToPartiallyApplied
 
@@ -22,6 +22,12 @@ final class BooleanOps(private val b: Boolean) extends AnyVal {
   @inline def either[L, R](l: => L, r: => R): Either[L, R] = fold(Right(r), Left(l))
 
   @inline def eitherNel[L, R](ifFalse: => L, ifTrue: => R): EitherNel[L, R] = either(NonEmptyList.one(ifFalse), ifTrue)
+
+  @inline def validated[L, R](ifFalse: => L, ifTrue: => R): Validated[L, R] =
+    fold(Validated.valid(ifTrue), Validated.invalid(ifFalse))
+
+  @inline def validatedNec[L, R](ifFalse: => L, ifTrue: => R): ValidatedNec[L, R] =
+    fold(Validated.validNec(ifTrue), Validated.invalidNec(ifFalse))
 
   @inline def validatedNel[L, R](ifFalse: => L, ifTrue: => R): ValidatedNel[L, R] =
     fold(Validated.validNel(ifTrue), Validated.invalidNel(ifFalse))

--- a/shared/src/test/scala/mouse/BooleanSyntaxTest.scala
+++ b/shared/src/test/scala/mouse/BooleanSyntaxTest.scala
@@ -19,6 +19,16 @@ class BooleanSyntaxTest extends MouseSuite {
     assertEquals(false.eitherNel("error", 1), Either.left(NonEmptyList.one("error")))
   }
 
+  test("BooleanSyntax.validated") {
+    assertEquals(true.validated("error", 1), Validated.valid(1))
+    assertEquals(false.validated("error", 1), Validated.invalid("error"))
+  }
+
+  test("BooleanSyntax.validatedNec") {
+    assertEquals(true.validatedNec("error", 1), Validated.validNec(1))
+    assertEquals(false.validatedNec("error", 1), Validated.invalidNec("error"))
+  }
+
   test("BooleanSyntax.validatedNel") {
     assertEquals(true.validatedNel("error", 1), Validated.validNel(1))
     assertEquals(false.validatedNel("error", 1), Validated.invalidNel("error"))


### PR DESCRIPTION
These additional extensions aligns the boolean to validated methods with similar methods in Cats, which usually provide all three options.
