### PR TITLE
Add getOrRaiseF

### DIFF
--- a/shared/src/test/scala/mouse/FEitherSyntaxTest.scala
+++ b/shared/src/test/scala/mouse/FEitherSyntaxTest.scala
@@ -3,6 +3,8 @@ package mouse
 import cats.data.EitherT
 import cats.syntax.either._
 
+import scala.util.{Failure, Success, Try}
+
 class FEitherSyntaxTest extends MouseSuite {
   private val rightValue = List(42.asRight[String])
   private val leftValue = List("42".asLeft[Int])
@@ -40,6 +42,22 @@ class FEitherSyntaxTest extends MouseSuite {
   test("FEitherSyntax.getOrElseIn") {
     assertEquals(rightValue.getOrElseIn(0), List(42))
     assertEquals(leftValue.getOrElseIn(0), List(0))
+  }
+
+  test("FEitherSyntax.getOrRaise") {
+    val ex1 = new RuntimeException("BOOM 1!")
+    val ex2 = new RuntimeException("BOOM 2!")
+
+    assertEquals(Try(1.asRight).getOrRaise(ex1), Success(1))
+    assertEquals(Try("ERROR".asLeft).getOrRaise(ex1), Failure(ex1))
+    assertEquals(Try[Either[String, Int]](throw ex1).getOrRaise(ex2), Failure(ex1))
+  }
+
+  test("FEitherSyntax.getOrRaiseMsg") {
+    val ex1 = new RuntimeException("BOOM 1!")
+    assertEquals(Try(1.asRight).getOrRaiseMsg("BOOM!"), Success(1))
+    assertEquals(Try("ERROR".asLeft).getOrRaiseMsg("BOOM!").failed.map(_.getMessage), Success("BOOM!"))
+    assertEquals(Try[Either[String, Int]](throw ex1).getOrRaiseMsg("BOOM!"), Failure(ex1))
   }
 
   test("FEitherSyntax.getOrElseF") {

--- a/shared/src/test/scala/mouse/FOptionSyntaxTest.scala
+++ b/shared/src/test/scala/mouse/FOptionSyntaxTest.scala
@@ -4,6 +4,8 @@ import cats.data.OptionT
 import cats.data.EitherT
 import cats.syntax.either._
 
+import scala.util.{Failure, Success, Try}
+
 class FOptionSyntaxTest extends MouseSuite {
   test("FOptionSyntax.cata") {
     assertEquals(List(Option(1)).cata(0, _ => 2), List(2))
@@ -74,6 +76,22 @@ class FOptionSyntaxTest extends MouseSuite {
   test("FOptionSyntax.getOrElse") {
     assertEquals(List(Option(1)).getOrElse(0), List(1))
     assertEquals(List(Option.empty[Int]).getOrElse(0), List(0))
+  }
+
+  test("FOptionSyntax.getOrRaise") {
+    val ex1 = new RuntimeException("BOOM 1!")
+    val ex2 = new RuntimeException("BOOM 2!")
+
+    assertEquals(Try(Option(1)).getOrRaise(ex1), Success(1))
+    assertEquals(Try(Option.empty[Int]).getOrRaise(ex1), Failure(ex1))
+    assertEquals(Try[Option[Int]](throw ex1).getOrRaise(ex2), Failure(ex1))
+  }
+
+  test("FOptionSyntax.getOrRaiseMsg") {
+    val ex1 = new RuntimeException("BOOM 1!")
+    assertEquals(Try(Option(1)).getOrRaiseMsg("BOOM!"), Success(1))
+    assertEquals(Try(Option.empty[Int]).getOrRaiseMsg("BOOM!").failed.map(_.getMessage), Success("BOOM!"))
+    assertEquals(Try[Option[Int]](throw ex1).getOrRaiseMsg("BOOM!"), Failure(ex1))
   }
 
   test("FOptionSyntax.getOrElseF") {


### PR DESCRIPTION
Hi, dealing with nested effects is always complex and sometimes verbose, I found helpful these two methods in my codebase and I'd like to propose them here.

`getOrRaiseF`  and `getOrRaiseMsgF` given `F[G[A]]` where `F` is a `MonadError` and `G` a foldable like `Option` and `Either` we can either get the nested value or raise an error in `F` if the value is missing ( since either is right biased).

Example
```scala
val fga: Try[Option[Int]] = Success(None)
val result: Try[Int] = fga.getOrRaiseMsgF("BOOM!")// = Failure(RuntimeException("BOOM!")
```


What do you think? (There are alternatives already in place? )