### PR TITLE
Add project name to sbt root project.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,6 +13,9 @@ ThisBuild / tlSiteApiUrl := Some(url("https://www.javadoc.io/doc/org.typelevel/m
 
 lazy val root = project
   .in(file("."))
+  .settings(
+    name := "mouse"
+  )
   .aggregate(js, jvm)
   .enablePlugins(NoPublishPlugin)
 


### PR DESCRIPTION
Importing `mouse` in IntelliJ ( I didn't try with other IDEs) the project name is `root` since there isn't any name specified to the main root SBT project. 
This is annoying when you want to open the project and, searching for `mouse` you get no results

<img width="340" alt="Screenshot 2022-03-20 at 00 06 00" src="https://user-images.githubusercontent.com/31506564/159141591-2d6e08f2-e11b-4db5-b905-43db5f1b87f1.png">

<img width="376" alt="Screenshot 2022-03-20 at 00 21 15" src="https://user-images.githubusercontent.com/31506564/159141692-27df5586-9a51-4c2b-8074-41658325d2c2.png">
