### PR TITLE
Clean up sbt plugins

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,11 @@ jobs:
         os: [ubuntu-latest]
         scala: [2.12.15, 3.0.2, 2.13.8]
         java: [temurin@8, temurin@17]
+        exclude:
+          - scala: 2.12.15
+            java: temurin@17
+          - scala: 3.0.2
+            java: temurin@17
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)
@@ -86,6 +91,10 @@ jobs:
 
       - name: Check formatting
         run: sbt '++${{ matrix.scala }}' scalafmtCheckAll 'project /' scalafmtSbtCheck
+
+      - name: Check headers and formatting
+        if: matrix.java == 'temurin@8'
+        run: sbt '++${{ matrix.scala }}' headerCheckAll scalafmtCheckAll 'project /' scalafmtSbtCheck
 
       - name: Test
         run: sbt '++${{ matrix.scala }}' test
@@ -179,26 +188,6 @@ jobs:
           name: target-${{ matrix.os }}-${{ matrix.java }}-2.12.15
 
       - name: Inflate target directories (2.12.15)
-        run: |
-          tar xf targets.tar
-          rm targets.tar
-
-      - name: Download target directories (2.12.15)
-        uses: actions/download-artifact@v2
-        with:
-          name: target-${{ matrix.os }}-${{ matrix.java }}-2.12.15
-
-      - name: Inflate target directories (2.12.15)
-        run: |
-          tar xf targets.tar
-          rm targets.tar
-
-      - name: Download target directories (3.0.2)
-        uses: actions/download-artifact@v2
-        with:
-          name: target-${{ matrix.os }}-${{ matrix.java }}-3.0.2
-
-      - name: Inflate target directories (3.0.2)
         run: |
           tar xf targets.tar
           rm targets.tar

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016 Ben Hutchison
+Copyright (c) 2016 Typelevel
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/build.sbt
+++ b/build.sbt
@@ -33,11 +33,12 @@ lazy val cross = crossProject(JSPlatform, JVMPlatform)
     developers := List(
       Developer("benhutchison", "Ben Hutchison", "brhutchison@gmail.com", url = url("https://github.com/benhutchison"))
     ),
-    scalacOptions ++= Seq("-feature", "-deprecation", "-language:implicitConversions", "-language:higherKinds"),
+    scalacOptions ++=
+      (if (tlIsScala3.value) Nil
+       else Seq("-language:implicitConversions", "-language:higherKinds")),
     scalacOptions ++= {
       scalaVersion.value match {
         case v if v.startsWith("2.12") => Seq("-Ypartial-unification")
-        case v if v.startsWith("3")    => Seq("-source", "3.0-migration")
         case _                         => Nil
       }
     },

--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,8 @@ ThisBuild / tlSiteApiUrl := Some(url("https://www.javadoc.io/doc/org.typelevel/m
 lazy val root = project
   .in(file("."))
   .settings(
-    name := "mouse"
+    name := "mouse",
+    licenses := List(License.MIT)
   )
   .aggregate(js, jvm)
   .enablePlugins(NoPublishPlugin)
@@ -41,7 +42,8 @@ lazy val cross = crossProject(JSPlatform, JVMPlatform)
       }
     },
     mimaPreviousArtifacts ~= { _.filterNot(_.revision == "1.0.1") },
-    Compile / sourceGenerators += (Compile / sourceManaged).map(Boilerplate.gen).taskValue
+    Compile / sourceGenerators += (Compile / sourceManaged).map(Boilerplate.gen).taskValue,
+    licenses := List(License.MIT)
   )
   .jsSettings(
     crossScalaVersions := (ThisBuild / crossScalaVersions).value.filter(_.startsWith("2"))

--- a/build.sbt
+++ b/build.sbt
@@ -43,7 +43,8 @@ lazy val cross = crossProject(JSPlatform, JVMPlatform)
     },
     mimaPreviousArtifacts ~= { _.filterNot(_.revision == "1.0.1") },
     Compile / sourceGenerators += (Compile / sourceManaged).map(Boilerplate.gen).taskValue,
-    licenses := List(License.MIT)
+    licenses := List(License.MIT),
+    startYear := Some(2016)
   )
   .jsSettings(
     crossScalaVersions := (ThisBuild / crossScalaVersions).value.filter(_.startsWith("2"))

--- a/docs/index.md
+++ b/docs/index.md
@@ -65,13 +65,13 @@ res0.cata(msg => s"Message received: ${msg}", "No message")
 
 val t1 = scala.util.Try(new java.net.URL("https://www.github.com"))
 
-t1.cata(msg => s"URL is valid!", error => s"URL is invalid: ${error.getMessage}")
+t1.cata(_ => s"URL is valid!", error => s"URL is invalid: ${error.getMessage}")
 
 t1.toEither
 
 val t2 = scala.util.Try(new java.net.URL("https//www.github.com"))
 
-t2.cata(msg => s"URL is valid!", error => s"URL is invalid: ${error.getMessage}")
+t2.cata(_ => s"URL is valid!", error => s"URL is invalid: ${error.getMessage}")
 
 t2.toEither
 

--- a/js/src/main/scala/mouse/js.scala
+++ b/js/src/main/scala/mouse/js.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Typelevel
+ * Copyright (c) 2016 Typelevel
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in

--- a/js/src/main/scala/mouse/js.scala
+++ b/js/src/main/scala/mouse/js.scala
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2022 Typelevel
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package mouse
 
 trait AllJsSyntax

--- a/js/src/main/scala/mouse/package.scala
+++ b/js/src/main/scala/mouse/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Typelevel
+ * Copyright (c) 2016 Typelevel
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in

--- a/js/src/main/scala/mouse/package.scala
+++ b/js/src/main/scala/mouse/package.scala
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2022 Typelevel
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package object mouse extends MouseFunctions {
   object all extends AllSharedSyntax with AllJsSyntax
   object any extends AnySyntax

--- a/jvm/src/main/scala-2/src/main/scala/mouse/package.scala
+++ b/jvm/src/main/scala-2/src/main/scala/mouse/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Typelevel
+ * Copyright (c) 2016 Typelevel
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in

--- a/jvm/src/main/scala-2/src/main/scala/mouse/package.scala
+++ b/jvm/src/main/scala-2/src/main/scala/mouse/package.scala
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2022 Typelevel
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package object mouse extends MouseFunctions {
   object all extends AllSharedSyntax with AllJvmSyntax
   object any extends AnySyntax

--- a/jvm/src/main/scala-3/src/main/scala/mouse/package.scala
+++ b/jvm/src/main/scala-3/src/main/scala/mouse/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Typelevel
+ * Copyright (c) 2016 Typelevel
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in

--- a/jvm/src/main/scala-3/src/main/scala/mouse/package.scala
+++ b/jvm/src/main/scala-3/src/main/scala/mouse/package.scala
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2022 Typelevel
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package object mouse extends MouseFunctions {
   object all extends AllSharedSyntax with AllJvmSyntax
   object any extends AnySyntax

--- a/jvm/src/main/scala/mouse/jvm.scala
+++ b/jvm/src/main/scala/mouse/jvm.scala
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2022 Typelevel
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package mouse
 
 trait AllJvmSyntax extends StringJvmSyntax

--- a/jvm/src/main/scala/mouse/jvm.scala
+++ b/jvm/src/main/scala/mouse/jvm.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Typelevel
+ * Copyright (c) 2016 Typelevel
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in

--- a/jvm/src/main/scala/mouse/stringJvm.scala
+++ b/jvm/src/main/scala/mouse/stringJvm.scala
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2022 Typelevel
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package mouse
 
 import java.net.{MalformedURLException, URI, URISyntaxException, URL}

--- a/jvm/src/main/scala/mouse/stringJvm.scala
+++ b/jvm/src/main/scala/mouse/stringJvm.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Typelevel
+ * Copyright (c) 2016 Typelevel
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in

--- a/jvm/src/test/scala/mouse/StringJvmTests.scala
+++ b/jvm/src/test/scala/mouse/StringJvmTests.scala
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2022 Typelevel
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package mouse
 
 import java.net.{MalformedURLException, URI, URISyntaxException, URL}

--- a/jvm/src/test/scala/mouse/StringJvmTests.scala
+++ b/jvm/src/test/scala/mouse/StringJvmTests.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Typelevel
+ * Copyright (c) 2016 Typelevel
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in

--- a/jvm/src/test/scala/mouse/StringJvmTests.scala
+++ b/jvm/src/test/scala/mouse/StringJvmTests.scala
@@ -22,7 +22,6 @@
 package mouse
 
 import java.net.{MalformedURLException, URI, URISyntaxException, URL}
-import cats.Eq
 import cats.syntax.all._
 
 import java.util.UUID
@@ -33,13 +32,6 @@ class StringJvmTests extends MouseSuite with StringJvmSyntax {
   }
 
   test("parseURL") {
-    implicit val urlEq: Eq[URL] = Eq.fromUniversalEquals
-    implicit val malformedURLExceptionEq: Eq[MalformedURLException] =
-      new Eq[MalformedURLException] {
-        override def eqv(x: MalformedURLException, y: MalformedURLException): Boolean =
-          x.getMessage == y.getMessage
-      }
-
     assertEquals(
       "http://example.com".parseURL,
       new URL("http://example.com").asRight[MalformedURLException]

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,4 @@
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.10.0")
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.2.0")
-addSbtPlugin("org.typelevel" % "sbt-typelevel-ci-release" % "0.4.9")
-addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.6")
+addSbtPlugin("org.typelevel" % "sbt-typelevel" % "0.4.9")
 addSbtPlugin("org.typelevel" % "sbt-typelevel-site" % "0.4.9")

--- a/shared/src/main/scala-2/src/main/scala/mouse/all.scala
+++ b/shared/src/main/scala-2/src/main/scala/mouse/all.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Typelevel
+ * Copyright (c) 2016 Typelevel
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in

--- a/shared/src/main/scala-2/src/main/scala/mouse/all.scala
+++ b/shared/src/main/scala-2/src/main/scala/mouse/all.scala
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2022 Typelevel
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package mouse
 
 trait AllSharedSyntax

--- a/shared/src/main/scala-2/src/main/scala/mouse/tuple.scala
+++ b/shared/src/main/scala-2/src/main/scala/mouse/tuple.scala
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2022 Typelevel
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package mouse
 
 trait TupleSyntax {

--- a/shared/src/main/scala-2/src/main/scala/mouse/tuple.scala
+++ b/shared/src/main/scala-2/src/main/scala/mouse/tuple.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Typelevel
+ * Copyright (c) 2016 Typelevel
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in

--- a/shared/src/main/scala-3/src/main/scala/mouse/all.scala
+++ b/shared/src/main/scala-3/src/main/scala/mouse/all.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Typelevel
+ * Copyright (c) 2016 Typelevel
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in

--- a/shared/src/main/scala-3/src/main/scala/mouse/all.scala
+++ b/shared/src/main/scala-3/src/main/scala/mouse/all.scala
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2022 Typelevel
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package mouse
 
 trait AllSharedSyntax

--- a/shared/src/main/scala/mouse/MouseFunctions.scala
+++ b/shared/src/main/scala/mouse/MouseFunctions.scala
@@ -21,6 +21,8 @@
 
 package mouse
 
+import scala.annotation.nowarn
+
 trait MouseFunctions {
 
   /**
@@ -30,6 +32,6 @@ trait MouseFunctions {
    * @param a
    *   - the value to be evaluated and ignored.
    */
-  def ignore(a: Any): Unit = ()
+  def ignore(@nowarn a: Any): Unit = ()
 
 }

--- a/shared/src/main/scala/mouse/MouseFunctions.scala
+++ b/shared/src/main/scala/mouse/MouseFunctions.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Typelevel
+ * Copyright (c) 2016 Typelevel
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in

--- a/shared/src/main/scala/mouse/MouseFunctions.scala
+++ b/shared/src/main/scala/mouse/MouseFunctions.scala
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2022 Typelevel
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package mouse
 
 trait MouseFunctions {

--- a/shared/src/main/scala/mouse/any.scala
+++ b/shared/src/main/scala/mouse/any.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Typelevel
+ * Copyright (c) 2016 Typelevel
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in

--- a/shared/src/main/scala/mouse/any.scala
+++ b/shared/src/main/scala/mouse/any.scala
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2022 Typelevel
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package mouse
 
 import cats.Applicative

--- a/shared/src/main/scala/mouse/anyf.scala
+++ b/shared/src/main/scala/mouse/anyf.scala
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2022 Typelevel
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package mouse
 
 import cats.data.EitherT

--- a/shared/src/main/scala/mouse/anyf.scala
+++ b/shared/src/main/scala/mouse/anyf.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Typelevel
+ * Copyright (c) 2016 Typelevel
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in

--- a/shared/src/main/scala/mouse/boolean.scala
+++ b/shared/src/main/scala/mouse/boolean.scala
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2022 Typelevel
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package mouse
 
 import cats.data.{EitherNel, NonEmptyList, Validated, ValidatedNec, ValidatedNel}

--- a/shared/src/main/scala/mouse/boolean.scala
+++ b/shared/src/main/scala/mouse/boolean.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Typelevel
+ * Copyright (c) 2016 Typelevel
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in

--- a/shared/src/main/scala/mouse/double.scala
+++ b/shared/src/main/scala/mouse/double.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Typelevel
+ * Copyright (c) 2016 Typelevel
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in

--- a/shared/src/main/scala/mouse/double.scala
+++ b/shared/src/main/scala/mouse/double.scala
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2022 Typelevel
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package mouse
 
 trait DoubleSyntax {

--- a/shared/src/main/scala/mouse/fboolean.scala
+++ b/shared/src/main/scala/mouse/fboolean.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Typelevel
+ * Copyright (c) 2016 Typelevel
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in

--- a/shared/src/main/scala/mouse/fboolean.scala
+++ b/shared/src/main/scala/mouse/fboolean.scala
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2022 Typelevel
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package mouse
 
 import cats.{Functor, Monad}

--- a/shared/src/main/scala/mouse/feither.scala
+++ b/shared/src/main/scala/mouse/feither.scala
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2022 Typelevel
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package mouse
 
 import cats.data.EitherT

--- a/shared/src/main/scala/mouse/feither.scala
+++ b/shared/src/main/scala/mouse/feither.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Typelevel
+ * Copyright (c) 2016 Typelevel
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in

--- a/shared/src/main/scala/mouse/fnested.scala
+++ b/shared/src/main/scala/mouse/fnested.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Typelevel
+ * Copyright (c) 2016 Typelevel
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in

--- a/shared/src/main/scala/mouse/fnested.scala
+++ b/shared/src/main/scala/mouse/fnested.scala
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2022 Typelevel
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package mouse
 
 import cats.{FlatMap, Functor}

--- a/shared/src/main/scala/mouse/foption.scala
+++ b/shared/src/main/scala/mouse/foption.scala
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2022 Typelevel
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package mouse
 
 import cats.data.EitherT

--- a/shared/src/main/scala/mouse/foption.scala
+++ b/shared/src/main/scala/mouse/foption.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Typelevel
+ * Copyright (c) 2016 Typelevel
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in

--- a/shared/src/main/scala/mouse/ftuple.scala
+++ b/shared/src/main/scala/mouse/ftuple.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Typelevel
+ * Copyright (c) 2016 Typelevel
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in

--- a/shared/src/main/scala/mouse/ftuple.scala
+++ b/shared/src/main/scala/mouse/ftuple.scala
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2022 Typelevel
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package mouse
 
 trait FTupleSyntax extends FTupleNSyntax

--- a/shared/src/main/scala/mouse/int.scala
+++ b/shared/src/main/scala/mouse/int.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Typelevel
+ * Copyright (c) 2016 Typelevel
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in

--- a/shared/src/main/scala/mouse/int.scala
+++ b/shared/src/main/scala/mouse/int.scala
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2022 Typelevel
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package mouse
 
 trait IntSyntax {

--- a/shared/src/main/scala/mouse/long.scala
+++ b/shared/src/main/scala/mouse/long.scala
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2022 Typelevel
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package mouse
 
 trait LongSyntax {

--- a/shared/src/main/scala/mouse/long.scala
+++ b/shared/src/main/scala/mouse/long.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Typelevel
+ * Copyright (c) 2016 Typelevel
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in

--- a/shared/src/main/scala/mouse/map.scala
+++ b/shared/src/main/scala/mouse/map.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Typelevel
+ * Copyright (c) 2016 Typelevel
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in

--- a/shared/src/main/scala/mouse/map.scala
+++ b/shared/src/main/scala/mouse/map.scala
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2022 Typelevel
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package mouse
 
 import cats.{Applicative, Semigroup}

--- a/shared/src/main/scala/mouse/option.scala
+++ b/shared/src/main/scala/mouse/option.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Typelevel
+ * Copyright (c) 2016 Typelevel
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in

--- a/shared/src/main/scala/mouse/option.scala
+++ b/shared/src/main/scala/mouse/option.scala
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2022 Typelevel
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package mouse
 
 import scala.util.{Failure, Success, Try}

--- a/shared/src/main/scala/mouse/partialFunction.scala
+++ b/shared/src/main/scala/mouse/partialFunction.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Typelevel
+ * Copyright (c) 2016 Typelevel
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in

--- a/shared/src/main/scala/mouse/partialFunction.scala
+++ b/shared/src/main/scala/mouse/partialFunction.scala
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2022 Typelevel
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package mouse
 
 trait PartialFunctionLift {

--- a/shared/src/main/scala/mouse/string.scala
+++ b/shared/src/main/scala/mouse/string.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Typelevel
+ * Copyright (c) 2016 Typelevel
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in

--- a/shared/src/main/scala/mouse/string.scala
+++ b/shared/src/main/scala/mouse/string.scala
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2022 Typelevel
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package mouse
 
 import cats.data.Validated

--- a/shared/src/main/scala/mouse/try.scala
+++ b/shared/src/main/scala/mouse/try.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Typelevel
+ * Copyright (c) 2016 Typelevel
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in

--- a/shared/src/main/scala/mouse/try.scala
+++ b/shared/src/main/scala/mouse/try.scala
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2022 Typelevel
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package mouse
 
 import cats.Applicative

--- a/shared/src/test/scala-2/mouse/MouseSuite.scala
+++ b/shared/src/test/scala-2/mouse/MouseSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Typelevel
+ * Copyright (c) 2016 Typelevel
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in

--- a/shared/src/test/scala-2/mouse/MouseSuite.scala
+++ b/shared/src/test/scala-2/mouse/MouseSuite.scala
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2022 Typelevel
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package mouse
 
 import cats.Eq

--- a/shared/src/test/scala-2/mouse/TupleSyntaxTest.scala
+++ b/shared/src/test/scala-2/mouse/TupleSyntaxTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Typelevel
+ * Copyright (c) 2016 Typelevel
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in

--- a/shared/src/test/scala-2/mouse/TupleSyntaxTest.scala
+++ b/shared/src/test/scala-2/mouse/TupleSyntaxTest.scala
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2022 Typelevel
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package mouse
 
 class TupleSyntaxTest extends MouseSuite {

--- a/shared/src/test/scala-3/mouse/MouseSuite.scala
+++ b/shared/src/test/scala-3/mouse/MouseSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Typelevel
+ * Copyright (c) 2016 Typelevel
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in

--- a/shared/src/test/scala-3/mouse/MouseSuite.scala
+++ b/shared/src/test/scala-3/mouse/MouseSuite.scala
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2022 Typelevel
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package mouse
 
 import cats.Eq

--- a/shared/src/test/scala/mouse/AnyFSyntaxTest.scala
+++ b/shared/src/test/scala/mouse/AnyFSyntaxTest.scala
@@ -24,7 +24,6 @@ package mouse
 import cats.data.EitherT
 import cats.data.OptionT
 import cats.syntax.option._
-import cats.syntax.functor._
 import cats.syntax.either._
 import cats.{~>, Id}
 

--- a/shared/src/test/scala/mouse/AnyFSyntaxTest.scala
+++ b/shared/src/test/scala/mouse/AnyFSyntaxTest.scala
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2022 Typelevel
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package mouse
 
 import cats.data.EitherT

--- a/shared/src/test/scala/mouse/AnyFSyntaxTest.scala
+++ b/shared/src/test/scala/mouse/AnyFSyntaxTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Typelevel
+ * Copyright (c) 2016 Typelevel
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in

--- a/shared/src/test/scala/mouse/AnySyntaxTest.scala
+++ b/shared/src/test/scala/mouse/AnySyntaxTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Typelevel
+ * Copyright (c) 2016 Typelevel
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in

--- a/shared/src/test/scala/mouse/AnySyntaxTest.scala
+++ b/shared/src/test/scala/mouse/AnySyntaxTest.scala
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2022 Typelevel
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package mouse
 
 class AnySyntaxTest extends MouseSuite with MouseFunctions {

--- a/shared/src/test/scala/mouse/BooleanSyntaxTest.scala
+++ b/shared/src/test/scala/mouse/BooleanSyntaxTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Typelevel
+ * Copyright (c) 2016 Typelevel
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in

--- a/shared/src/test/scala/mouse/BooleanSyntaxTest.scala
+++ b/shared/src/test/scala/mouse/BooleanSyntaxTest.scala
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2022 Typelevel
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package mouse
 
 import cats.data.{NonEmptyList, Validated}

--- a/shared/src/test/scala/mouse/DoubleSyntaxTest.scala
+++ b/shared/src/test/scala/mouse/DoubleSyntaxTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Typelevel
+ * Copyright (c) 2016 Typelevel
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in

--- a/shared/src/test/scala/mouse/DoubleSyntaxTest.scala
+++ b/shared/src/test/scala/mouse/DoubleSyntaxTest.scala
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2022 Typelevel
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package mouse
 
 class DoubleSyntaxTest extends MouseSuite {

--- a/shared/src/test/scala/mouse/FBooleanSyntaxTests.scala
+++ b/shared/src/test/scala/mouse/FBooleanSyntaxTests.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Typelevel
+ * Copyright (c) 2016 Typelevel
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in

--- a/shared/src/test/scala/mouse/FBooleanSyntaxTests.scala
+++ b/shared/src/test/scala/mouse/FBooleanSyntaxTests.scala
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2022 Typelevel
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package mouse
 
 import cats.{Eval, Id}

--- a/shared/src/test/scala/mouse/FEitherSyntaxTest.scala
+++ b/shared/src/test/scala/mouse/FEitherSyntaxTest.scala
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2022 Typelevel
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package mouse
 
 import cats.data.EitherT

--- a/shared/src/test/scala/mouse/FEitherSyntaxTest.scala
+++ b/shared/src/test/scala/mouse/FEitherSyntaxTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Typelevel
+ * Copyright (c) 2016 Typelevel
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in

--- a/shared/src/test/scala/mouse/FNestedSyntaxTest.scala
+++ b/shared/src/test/scala/mouse/FNestedSyntaxTest.scala
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2022 Typelevel
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package mouse
 
 class FNestedSyntaxTest extends MouseSuite {

--- a/shared/src/test/scala/mouse/FNestedSyntaxTest.scala
+++ b/shared/src/test/scala/mouse/FNestedSyntaxTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Typelevel
+ * Copyright (c) 2016 Typelevel
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in

--- a/shared/src/test/scala/mouse/FOptionSyntaxTest.scala
+++ b/shared/src/test/scala/mouse/FOptionSyntaxTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Typelevel
+ * Copyright (c) 2016 Typelevel
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in

--- a/shared/src/test/scala/mouse/FOptionSyntaxTest.scala
+++ b/shared/src/test/scala/mouse/FOptionSyntaxTest.scala
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2022 Typelevel
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package mouse
 
 import cats.data.OptionT

--- a/shared/src/test/scala/mouse/FTupleNSyntaxSuite.scala
+++ b/shared/src/test/scala/mouse/FTupleNSyntaxSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Typelevel
+ * Copyright (c) 2016 Typelevel
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in

--- a/shared/src/test/scala/mouse/FTupleNSyntaxSuite.scala
+++ b/shared/src/test/scala/mouse/FTupleNSyntaxSuite.scala
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2022 Typelevel
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package mouse
 
 import org.scalacheck.Prop._

--- a/shared/src/test/scala/mouse/IntSyntaxTest.scala
+++ b/shared/src/test/scala/mouse/IntSyntaxTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Typelevel
+ * Copyright (c) 2016 Typelevel
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in

--- a/shared/src/test/scala/mouse/IntSyntaxTest.scala
+++ b/shared/src/test/scala/mouse/IntSyntaxTest.scala
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2022 Typelevel
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package mouse
 
 class IntSyntaxTest extends MouseSuite {

--- a/shared/src/test/scala/mouse/LongSyntaxTest.scala
+++ b/shared/src/test/scala/mouse/LongSyntaxTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Typelevel
+ * Copyright (c) 2016 Typelevel
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in

--- a/shared/src/test/scala/mouse/LongSyntaxTest.scala
+++ b/shared/src/test/scala/mouse/LongSyntaxTest.scala
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2022 Typelevel
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package mouse
 
 class LongSyntaxTest extends MouseSuite {

--- a/shared/src/test/scala/mouse/MapSyntaxTest.scala
+++ b/shared/src/test/scala/mouse/MapSyntaxTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Typelevel
+ * Copyright (c) 2016 Typelevel
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in

--- a/shared/src/test/scala/mouse/MapSyntaxTest.scala
+++ b/shared/src/test/scala/mouse/MapSyntaxTest.scala
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2022 Typelevel
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package mouse
 
 class MapSyntaxTest extends MouseSuite {

--- a/shared/src/test/scala/mouse/OptionSyntaxTest.scala
+++ b/shared/src/test/scala/mouse/OptionSyntaxTest.scala
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2022 Typelevel
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package mouse
 
 import scala.util.{Failure, Success}

--- a/shared/src/test/scala/mouse/OptionSyntaxTest.scala
+++ b/shared/src/test/scala/mouse/OptionSyntaxTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Typelevel
+ * Copyright (c) 2016 Typelevel
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in

--- a/shared/src/test/scala/mouse/PartialFunctionLiftTest.scala
+++ b/shared/src/test/scala/mouse/PartialFunctionLiftTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Typelevel
+ * Copyright (c) 2016 Typelevel
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in

--- a/shared/src/test/scala/mouse/PartialFunctionLiftTest.scala
+++ b/shared/src/test/scala/mouse/PartialFunctionLiftTest.scala
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2022 Typelevel
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package mouse
 
 class PartialFunctionLiftTest extends MouseSuite {

--- a/shared/src/test/scala/mouse/StringSyntaxTests.scala
+++ b/shared/src/test/scala/mouse/StringSyntaxTests.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Typelevel
+ * Copyright (c) 2016 Typelevel
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in

--- a/shared/src/test/scala/mouse/StringSyntaxTests.scala
+++ b/shared/src/test/scala/mouse/StringSyntaxTests.scala
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2022 Typelevel
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package mouse
 
 import cats.syntax.all._

--- a/shared/src/test/scala/mouse/TrySyntaxTest.scala
+++ b/shared/src/test/scala/mouse/TrySyntaxTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Typelevel
+ * Copyright (c) 2016 Typelevel
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in

--- a/shared/src/test/scala/mouse/TrySyntaxTest.scala
+++ b/shared/src/test/scala/mouse/TrySyntaxTest.scala
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2022 Typelevel
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package mouse
 
 import cats.syntax.eq._


### PR DESCRIPTION
This PR includes:
* a migration to the `sbt-typelevel` plugin;
* a generation of headers;
* a fixing of compilation caused due to new compiler flags from the `sbt-typelevel` plugin. Due to new compiler settings - every warning at the CI became fatal. And I think that is pretty good. 