### PR TITLE
Add bimapIn, swapIn and mergeIn to FEitherSyntax

### DIFF
--- a/shared/src/test/scala/mouse/FEitherSyntaxTest.scala
+++ b/shared/src/test/scala/mouse/FEitherSyntaxTest.scala
@@ -148,4 +148,19 @@ class FEitherSyntaxTest extends MouseSuite {
   test("FEitherSyntax.asRightF") {
     assertEquals(FEitherSyntax.asRightF[List, String, Int](42), List(Right(42)))
   }
+
+  test("FEitherSyntax.bimapIn") {
+    assertEquals(rightValue.bimapIn(_.toInt, _.toString), List("42".asRight[Int]))
+    assertEquals(leftValue.bimapIn(_.toInt, _.toString), List(42.asLeft[String]))
+  }
+
+  test("FEitherSyntax.swapIn") {
+    assertEquals(rightValue.swapIn, List(42.asLeft[String]))
+    assertEquals(leftValue.swapIn, List("42".asRight[Int]))
+  }
+
+  test("FEitherSyntax.mergeIn") {
+    assertEquals(List(42.asRight[Int]).mergeIn, List(42))
+    assertEquals(List("42".asLeft[String]).mergeIn, List("42"))
+  }
 }


### PR DESCRIPTION
Hi! First of all, thanks for this great library.
I use IO[Either[A, B]] heavily and I found these functions quite useful. I think they fit nice since `EitherT` has similar functions. What do you think?