### PR TITLE
Add `toRightIn` and `toOptionIn`

### DIFF
--- a/shared/src/main/scala/mouse/feither.scala
+++ b/shared/src/main/scala/mouse/feither.scala
@@ -129,6 +129,9 @@ final class FEitherOps[F[_], L, R](private val felr: F[Either[L, R]]) extends An
       case _              => f
     }
 
+  def toOptionIn(implicit F: Functor[F]): F[Option[R]] =
+    F.map(felr)(_.toOption)
+
   def traverseIn[G[_]: Applicative, A](f: R => G[A])(implicit F: Functor[F]): F[G[Either[L, A]]] =
     F.map(felr)(elr => catsStdInstancesForEither[L].traverse(elr)(f))
 

--- a/shared/src/main/scala/mouse/foption.scala
+++ b/shared/src/main/scala/mouse/foption.scala
@@ -115,6 +115,12 @@ final class FOptionOps[F[_], A](private val foa: F[Option[A]]) extends AnyVal {
       case x    => F.pure(x)
     }
 
+  def toRightIn[L](left: => L)(implicit F: Functor[F]): F[Either[L, A]] =
+    F.map(foa) {
+      case None    => Left(left)
+      case Some(a) => Right(a)
+    }
+
   def traverseIn[G[_]: Applicative, B](f: A => G[B])(implicit F: Functor[F]): F[G[Option[B]]] =
     F.map(foa)(a => Traverse[Option].traverse(a)(f))
 

--- a/shared/src/test/scala/mouse/FEitherSyntaxTest.scala
+++ b/shared/src/test/scala/mouse/FEitherSyntaxTest.scala
@@ -126,6 +126,11 @@ class FEitherSyntaxTest extends MouseSuite {
     assertEquals(leftValue.orElseF(List(0.asRight[String])), List(0.asRight[String]))
   }
 
+  test("FEitherSyntax.toOptionIn") {
+    assertEquals(rightValue.toOptionIn, List(Option(42)))
+    assertEquals(leftValue.toOptionIn, List(Option.empty[Int]))
+  }
+
   test("FEitherSyntax.traverseIn") {
     assertEquals(rightValue.traverseIn(_ => Option(1)), List(Option(1.asRight[String])))
     assertEquals(leftValue.traverseIn(_ => Option(0)), List(Option("42".asLeft[Int])))

--- a/shared/src/test/scala/mouse/FOptionSyntaxTest.scala
+++ b/shared/src/test/scala/mouse/FOptionSyntaxTest.scala
@@ -135,6 +135,12 @@ class FOptionSyntaxTest extends MouseSuite {
     assertEquals(List(Option.empty[Int]).orElseF(List(Option(0))), List(Option(0)))
   }
 
+  test("FOptionSyntax.toRightIn") {
+    assertEquals(List(Option(1)).toRightIn("none"), List(1.asRight[String]))
+    assertEquals(List.empty[Option[Int]].toRightIn("none"), List.empty[Either[String, Int]])
+    assertEquals(List(Option.empty[Int]).toRightIn("none"), List("none".asLeft[Int]))
+  }
+
   test("FOptionSyntax.traverseIn") {
     assertEquals(List(Option(1)).traverseIn(a => List(a * 2)), List(List(Option(2))))
     assertEquals(List.empty[Option[Int]].traverseIn(a => List(a * 2)), List.empty[List[Option[Int]]])


### PR DESCRIPTION
This pull request adds `toRightIn` to `FOptionOps` and `toOptionIn` to `FEitherOps`, as discussed in #338. I can also add `toLeftInF` and `toRightInF` (as suggested by @satorg) in a separate PR, if you find these two methods helpful as well.