### PR TITLE
Add `toLeftInF` and `toRightInF`

### DIFF
--- a/shared/src/main/scala/mouse/foption.scala
+++ b/shared/src/main/scala/mouse/foption.scala
@@ -115,10 +115,28 @@ final class FOptionOps[F[_], A](private val foa: F[Option[A]]) extends AnyVal {
       case x    => F.pure(x)
     }
 
+  def toLeftIn[R](right: => R)(implicit F: Functor[F]): F[Either[A, R]] =
+    F.map(foa) {
+      case None    => Right(right)
+      case Some(a) => Left(a)
+    }
+
+  def toLeftInF[R](right: => F[R])(implicit F: Monad[F]): F[Either[A, R]] =
+    F.flatMap(foa) {
+      case None    => F.map(right)(Right(_))
+      case Some(a) => F.pure(Left(a))
+    }
+
   def toRightIn[L](left: => L)(implicit F: Functor[F]): F[Either[L, A]] =
     F.map(foa) {
       case None    => Left(left)
       case Some(a) => Right(a)
+    }
+
+  def toRightInF[L](left: => F[L])(implicit F: Monad[F]): F[Either[L, A]] =
+    F.flatMap(foa) {
+      case None    => F.map(left)(Left(_))
+      case Some(a) => F.pure(Right(a))
     }
 
   def traverseIn[G[_]: Applicative, B](f: A => G[B])(implicit F: Functor[F]): F[G[Option[B]]] =

--- a/shared/src/test/scala/mouse/FOptionSyntaxTest.scala
+++ b/shared/src/test/scala/mouse/FOptionSyntaxTest.scala
@@ -135,10 +135,28 @@ class FOptionSyntaxTest extends MouseSuite {
     assertEquals(List(Option.empty[Int]).orElseF(List(Option(0))), List(Option(0)))
   }
 
+  test("FOptionSyntax.toLeftIn") {
+    assertEquals(List(Option(1)).toLeftIn("right"), List(1.asLeft[String]))
+    assertEquals(List.empty[Option[Int]].toLeftIn("right"), List.empty[Either[Int, String]])
+    assertEquals(List(Option.empty[Int]).toLeftIn("right"), List("right".asRight[Int]))
+  }
+
+  test("FOptionSyntax.toLeftInF") {
+    assertEquals(List(Option(1)).toLeftInF(List("right")), List(1.asLeft[String]))
+    assertEquals(List.empty[Option[Int]].toLeftInF(List("right")), List.empty[Either[Int, String]])
+    assertEquals(List(Option.empty[Int]).toLeftInF(List("right")), List("right".asRight[Int]))
+  }
+
   test("FOptionSyntax.toRightIn") {
     assertEquals(List(Option(1)).toRightIn("none"), List(1.asRight[String]))
     assertEquals(List.empty[Option[Int]].toRightIn("none"), List.empty[Either[String, Int]])
     assertEquals(List(Option.empty[Int]).toRightIn("none"), List("none".asLeft[Int]))
+  }
+
+  test("FOptionSyntax.toRightInF") {
+    assertEquals(List(Option(1)).toRightInF(List("none")), List(1.asRight[String]))
+    assertEquals(List.empty[Option[Int]].toRightInF(List("none")), List.empty[Either[String, Int]])
+    assertEquals(List(Option.empty[Int]).toRightInF(List("none")), List("none".asLeft[Int]))
   }
 
   test("FOptionSyntax.traverseIn") {


### PR DESCRIPTION
This pull request adds `toLeftInF` and `toRightInF` to `FOptionOps`, as proposed by @satorg in #338. It also adds missing `toLeftIn` method, for symmetry