### PR TITLE
Deprecate `left` and `right` methods on Option

### DIFF
--- a/shared/src/main/scala/mouse/option.scala
+++ b/shared/src/main/scala/mouse/option.scala
@@ -39,11 +39,13 @@ final class OptionOps[A](private val oa: Option[A]) extends AnyVal {
    * Same as oa.toRight except that it fixes the type to Either[B, A] On Scala prior to 2.12, toRight returns
    * `Serializable with Product with Either[B, A]`
    */
+  @deprecated("Use toRight instead", "1.2.0")
   @inline def right[B](b: => B): Either[B, A] = oa.toRight(b)
 
   /**
    * Same as oa.toLeft except that it fixes the type to Either[A, B] On Scala prior to 2.12, toLeft returns
    * `Serializable with Product with Either[A, B]`
    */
+  @deprecated("Use toLeft instead", "1.2.0")
   @inline def left[B](b: => B): Either[A, B] = oa.toLeft(b)
 }

--- a/shared/src/test/scala/mouse/OptionSyntaxTest.scala
+++ b/shared/src/test/scala/mouse/OptionSyntaxTest.scala
@@ -23,6 +23,7 @@ package mouse
 
 import scala.util.{Failure, Success}
 
+@annotation.nowarn("cat=deprecation")
 class OptionSyntaxTest extends MouseSuite {
   implicit class ExtraTest[A](a: A) {
     def shouldBeA[T](implicit ev: T =:= A): Unit = ()
@@ -46,7 +47,7 @@ class OptionSyntaxTest extends MouseSuite {
     Option(3).right("S").shouldBeA[Either[String, Int]]
   }
 
-  test("OptionSyntax.") {
+  test("OptionSyntax.left") {
     assertEquals(Option(3).left("S"), Option(3).toLeft("S"))
     assertEquals(None.left("S"), None.toLeft("S"))
     Option(3).left("S").shouldBeA[Either[Int, String]]

--- a/shared/src/test/scala/mouse/OptionSyntaxTest.scala
+++ b/shared/src/test/scala/mouse/OptionSyntaxTest.scala
@@ -21,9 +21,9 @@
 
 package mouse
 
+import scala.annotation.nowarn
 import scala.util.{Failure, Success}
 
-@annotation.nowarn("cat=deprecation")
 class OptionSyntaxTest extends MouseSuite {
   implicit class ExtraTest[A](a: A) {
     def shouldBeA[T](implicit ev: T =:= A): Unit = ()
@@ -41,15 +41,22 @@ class OptionSyntaxTest extends MouseSuite {
     assertEquals(Option.empty[Int].toTry(ex), Failure(ex))
   }
 
-  test("OptionSyntax.right") {
-    assertEquals(Option(3).right("S"), Option(3).toRight("S"))
-    assertEquals(None.right("S"), None.toRight("S"))
-    Option(3).right("S").shouldBeA[Either[String, Int]]
-  }
+  @nowarn("cat=deprecation")
+  private def rightTest(): Unit =
+    test("OptionSyntax.right") {
+      assertEquals(Option(3).right("S"), Option(3).toRight("S"))
+      assertEquals(None.right("S"), None.toRight("S"))
+      Option(3).right("S").shouldBeA[Either[String, Int]]
+    }
 
-  test("OptionSyntax.left") {
+  rightTest()
+
+  @nowarn("cat=deprecation")
+  private def leftTest(): Unit = test("OptionSyntax.left") {
     assertEquals(Option(3).left("S"), Option(3).toLeft("S"))
     assertEquals(None.left("S"), None.toLeft("S"))
     Option(3).left("S").shouldBeA[Either[Int, String]]
   }
+
+  leftTest()
 }


### PR DESCRIPTION
Since support for scala 2.11 has been dropped and the next scala versions has correct return type, we can deprecate this methods and remove in the future