### PR TITLE
introduce leftWidenIn for F[Either[L, R]]

### DIFF
--- a/shared/src/main/scala/mouse/feither.scala
+++ b/shared/src/main/scala/mouse/feither.scala
@@ -90,6 +90,9 @@ final class FEitherOps[F[_], L, R](private val felr: F[Either[L, R]]) extends An
       case r @ Right(_) => r.asInstanceOf[Right[A, R]]
     }
 
+  def leftWidenIn[A >: L](implicit F: Functor[F]): F[Either[A, R]] =
+    leftMapIn[A](_.asInstanceOf[A])
+
   def leftTraverseIn[G[_], A](f: L => G[A])(implicit F: Functor[F], G: Applicative[G]): F[G[Either[A, R]]] =
     F.map(felr) {
       case Left(left)   => G.map(f(left))(Left(_))

--- a/shared/src/main/scala/mouse/feither.scala
+++ b/shared/src/main/scala/mouse/feither.scala
@@ -91,7 +91,10 @@ final class FEitherOps[F[_], L, R](private val felr: F[Either[L, R]]) extends An
     }
 
   def leftWidenIn[A >: L](implicit F: Functor[F]): F[Either[A, R]] =
-    leftMapIn[A](_.asInstanceOf[A])
+    F.map(felr) {
+      case l @ Left(_)  => l.asInstanceOf[Left[A, R]]
+      case r @ Right(_) => r.asInstanceOf[Right[A, R]]
+    }
 
   def leftTraverseIn[G[_], A](f: L => G[A])(implicit F: Functor[F], G: Applicative[G]): F[G[Either[A, R]]] =
     F.map(felr) {

--- a/shared/src/test/scala/mouse/FEitherSyntaxTest.scala
+++ b/shared/src/test/scala/mouse/FEitherSyntaxTest.scala
@@ -45,6 +45,13 @@ class FEitherSyntaxTest extends MouseSuite {
     assertEquals(leftValue.flatMapIn(i => (i * 2).asRight[String]), leftValue)
   }
 
+  test("FEitherSyntax.leftWidenIn") {
+    val initial: Option[Either[List[Int], String]] = Option(List(1).asLeft[String])
+    val expected: Option[Either[Seq[Int], String]] = Option(Seq(1).asLeft[String])
+
+    assertEquals(initial.leftWidenIn[Seq[Int]], expected)
+  }
+
   test("FEitherSyntax.flatMapF") {
     assertEquals(rightValue.flatMapF(i => List((i * 2).asRight[String])), List(84.asRight[String]))
     assertEquals(leftValue.flatMapF(i => List((i * 2).asRight[String])), leftValue)


### PR DESCRIPTION
I think this might be a nice replacement for
```scala
_.leftMapIn[WiderType](identity)
```