### PR TITLE
Add `widenIn` to `FEither` syntax

### DIFF
--- a/shared/src/main/scala/mouse/feither.scala
+++ b/shared/src/main/scala/mouse/feither.scala
@@ -147,4 +147,9 @@ final class FEitherOps[F[_], L, R](private val felr: F[Either[L, R]]) extends An
   def liftEitherT: EitherT[F, L, R] =
     EitherT(felr)
 
+  def widenIn[A >: R](implicit F: Functor[F]): F[Either[L, A]] =
+    F.map(felr) {
+      case l @ Left(_)  => l.asInstanceOf[Left[L, A]]
+      case r @ Right(_) => r.asInstanceOf[Right[L, A]]
+    }
 }

--- a/shared/src/test/scala/mouse/FEitherSyntaxTest.scala
+++ b/shared/src/test/scala/mouse/FEitherSyntaxTest.scala
@@ -175,4 +175,11 @@ class FEitherSyntaxTest extends MouseSuite {
     assertEquals(List(42.asRight[Int]).mergeIn, List(42))
     assertEquals(List("42".asLeft[String]).mergeIn, List("42"))
   }
+
+  test("FEitherSyntax.widenIn") {
+    val initial: Option[Either[String, List[Int]]] = Option(List(1).asRight[String])
+    val expected: Option[Either[String, Seq[Int]]] = Option(Seq(1).asRight[String])
+
+    assertEquals(initial.widenIn[Seq[Int]], expected)
+  }
 }


### PR DESCRIPTION
This is a counterpart method for already added [`leftWidenIn`](https://github.com/typelevel/mouse/pull/375).