### PR TITLE
Reorganise `mouse` package object

### DIFF
--- a/js/src/main/scala-2/mouse/package.scala
+++ b/js/src/main/scala-2/mouse/package.scala
@@ -19,9 +19,9 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package object mouse extends MouseFunctions {
+package object mouse {
   object all extends AllSharedSyntax with AllJsSyntax
-  object any extends AnySyntax
+  object any extends AnySyntax with MouseFunctions
   object anyf extends AnyFSyntax
   object boolean extends BooleanSyntax
   object double extends DoubleSyntax

--- a/js/src/main/scala-3/mouse/package.scala
+++ b/js/src/main/scala-3/mouse/package.scala
@@ -19,9 +19,9 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package object mouse extends MouseFunctions {
+package object mouse {
   object all extends AllSharedSyntax with AllJsSyntax
-  object any extends AnySyntax
+  object any extends AnySyntax with MouseFunctions
   object anyf extends AnyFSyntax
   object boolean extends BooleanSyntax
   object double extends DoubleSyntax

--- a/jvm/src/main/scala-2/src/main/scala/mouse/package.scala
+++ b/jvm/src/main/scala-2/src/main/scala/mouse/package.scala
@@ -19,9 +19,9 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package object mouse extends MouseFunctions {
+package object mouse {
   object all extends AllSharedSyntax with AllJvmSyntax
-  object any extends AnySyntax
+  object any extends AnySyntax with MouseFunctions
   object anyf extends AnyFSyntax
   object boolean extends BooleanSyntax
   object double extends DoubleSyntax

--- a/jvm/src/main/scala-3/src/main/scala/mouse/package.scala
+++ b/jvm/src/main/scala-3/src/main/scala/mouse/package.scala
@@ -19,9 +19,9 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package object mouse extends MouseFunctions {
+package object mouse {
   object all extends AllSharedSyntax with AllJvmSyntax
-  object any extends AnySyntax
+  object any extends AnySyntax with MouseFunctions
   object anyf extends AnyFSyntax
   object boolean extends BooleanSyntax
   object double extends DoubleSyntax

--- a/native/src/main/scala-2/mouse/mouse.scala
+++ b/native/src/main/scala-2/mouse/mouse.scala
@@ -19,9 +19,9 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package object mouse extends MouseFunctions {
+package object mouse {
   object all extends AllSharedSyntax
-  object any extends AnySyntax
+  object any extends AnySyntax with MouseFunctions
   object anyf extends AnyFSyntax
   object boolean extends BooleanSyntax
   object double extends DoubleSyntax
@@ -30,6 +30,7 @@ package object mouse extends MouseFunctions {
   object fnested extends FNestedSyntax
   object foption extends FOptionSyntax
   object ftuple extends FTupleSyntax
+  object functions extends MouseFunctions
   object int extends IntSyntax
   object list extends ListSyntax
   object long extends LongSyntax

--- a/native/src/main/scala-3/mouse/package.scala
+++ b/native/src/main/scala-3/mouse/package.scala
@@ -19,9 +19,9 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package object mouse extends MouseFunctions {
+package object mouse {
   object all extends AllSharedSyntax
-  object any extends AnySyntax
+  object any extends AnySyntax with MouseFunctions
   object anyf extends AnyFSyntax
   object boolean extends BooleanSyntax
   object double extends DoubleSyntax

--- a/shared/src/main/scala-2/src/main/scala/mouse/all.scala
+++ b/shared/src/main/scala-2/src/main/scala/mouse/all.scala
@@ -35,6 +35,7 @@ trait AllSharedSyntax
     with ListSyntax
     with LongSyntax
     with MapSyntax
+    with MouseFunctions
     with OptionSyntax
     with PartialFunctionLift
     with SetSyntax

--- a/shared/src/main/scala-3/src/main/scala/mouse/all.scala
+++ b/shared/src/main/scala-3/src/main/scala/mouse/all.scala
@@ -35,6 +35,7 @@ trait AllSharedSyntax
     with ListSyntax
     with LongSyntax
     with MapSyntax
+    with MouseFunctions
     with OptionSyntax
     with PartialFunctionLift
     with SetSyntax

--- a/shared/src/test/scala/mouse/AnySyntaxTest.scala
+++ b/shared/src/test/scala/mouse/AnySyntaxTest.scala
@@ -21,7 +21,7 @@
 
 package mouse
 
-class AnySyntaxTest extends MouseSuite with MouseFunctions {
+class AnySyntaxTest extends MouseSuite {
   test("AnySyntax.|>") {
     assertEquals(true |> (!_), false)
 


### PR DESCRIPTION
Motivation: [inheritance for package objects was deprecated](https://github.com/scala/scala-dev/issues/441) some time ago. Also, this is not a binary-compatible change, so we can't fix that for the `1.x` series. 