### PR TITLE
Update the contributing guide

### DIFF
--- a/DEV.md
+++ b/DEV.md
@@ -15,7 +15,7 @@ short or generic names if possible.
 
 However, for new operations, simply providing a lazy by-name variant is often the best choice unless there are clear reasons (eg performance impact) for needing an eager variant.
  
-### Release Process
+## Release Process
 
 Mouse uses Github Actions, https://github.com/djspiewak/sbt-github-actions and https://github.com/typelevel/sbt-typelevel for CI releases. Use the Github Create Release feature to tag a release, and it will publish to Sonatype automatically (using @benhutchison credentials).
 

--- a/DEV.md
+++ b/DEV.md
@@ -20,3 +20,11 @@ However, for new operations, simply providing a lazy by-name variant is often th
 Mouse uses Github Actions, https://github.com/djspiewak/sbt-github-actions and https://github.com/typelevel/sbt-typelevel for CI releases. Use the Github Create Release feature to tag a release, and it will publish to Sonatype automatically (using @benhutchison credentials).
 
 sbt-release and sbt-ci-release is no longer in use.
+
+## Choosing the appropriate base branch
+
+There are two options for choosing a base branch for your PRs:
+
+* Use the `main` branch if you would like to deliver changes within the `1.x` series. It's for binary-compatible changes only.
+
+* Use the `series/2.x` branch if you would like to deliver changes within the `2.x` series. It's for non-binary-compatible changes and basically stands for the next major `mouse` release.

--- a/docs/contributing-guide.md
+++ b/docs/contributing-guide.md
@@ -23,6 +23,14 @@ Mouse uses Github Actions, [sbt-github-actions] and [sbt-typelevel] for CI relea
 Use the Github Create Release feature to tag a release, 
 and it will publish to Sonatype automatically (using @benhutchison credentials).
 
+### Choosing the appropriate base branch
+
+There are two options for choosing a base branch for your PRs:
+
+* Use the `main` branch if you would like to deliver changes within the `1.x` series. It's for binary-compatible changes only.
+
+* Use the `series/2.x` branch if you would like to deliver changes within the `2.x` series. It's for non-binary-compatible changes and basically stands for the next major `mouse` release.
+
 
 [sbt-github-actions]: https://github.com/djspiewak/sbt-github-actions
 [sbt-typelevel]: https://github.com/typelevel/sbt-typelevel


### PR DESCRIPTION
This adds a new section in the contributing guide which emphasises several `mouse` branches that are under active development.