### PR TITLE
Add asIn, voidIn, leftAsIn, leftVoidIn into foption and feither.

### DIFF
--- a/shared/src/main/scala/mouse/feither.scala
+++ b/shared/src/main/scala/mouse/feither.scala
@@ -90,6 +90,12 @@ final class FEitherOps[F[_], L, R](private val felr: F[Either[L, R]]) extends An
       case r @ Right(_) => r.asInstanceOf[Right[A, R]]
     }
 
+  def leftAsIn[B](b: => B)(implicit F: Functor[F]): F[Either[B, R]] =
+    leftMapIn(_ => b)
+
+  def leftVoidIn(implicit F: Functor[F]): F[Either[Unit, R]] =
+    leftAsIn(())
+
   def leftWidenIn[A >: L](implicit F: Functor[F]): F[Either[A, R]] =
     F.map(felr) {
       case l @ Left(_)  => l.asInstanceOf[Left[A, R]]
@@ -110,6 +116,12 @@ final class FEitherOps[F[_], L, R](private val felr: F[Either[L, R]]) extends An
 
   def mapIn[A](f: R => A)(implicit F: Functor[F]): F[Either[L, A]] =
     F.map(felr)(_.map(f))
+
+  def asIn[B](b: => B)(implicit F: Functor[F]): F[Either[L, B]] =
+    mapIn(_ => b)
+
+  def voidIn(implicit F: Functor[F]): F[Either[L, Unit]] =
+    asIn(())
 
   def bimapIn[A, B](left: L => A, right: R => B)(implicit F: Functor[F]): F[Either[A, B]] =
     F.map(felr) {

--- a/shared/src/main/scala/mouse/foption.scala
+++ b/shared/src/main/scala/mouse/foption.scala
@@ -103,6 +103,12 @@ final class FOptionOps[F[_], A](private val foa: F[Option[A]]) extends AnyVal {
   def mapIn[B](f: A => B)(implicit F: Functor[F]): F[Option[B]] =
     F.map(foa)(_.map(f))
 
+  def asIn[B](b: => B)(implicit F: Functor[F]): F[Option[B]] =
+    mapIn(_ => b)
+
+  def voidIn(implicit F: Functor[F]): F[Option[Unit]] =
+    asIn(())
+
   def orElseIn(default: Option[A])(implicit F: Functor[F]): F[Option[A]] =
     F.map(foa) {
       case None => default

--- a/shared/src/test/scala/mouse/FEitherSyntaxTest.scala
+++ b/shared/src/test/scala/mouse/FEitherSyntaxTest.scala
@@ -27,8 +27,8 @@ import cats.syntax.either._
 import scala.util.{Failure, Success, Try}
 
 class FEitherSyntaxTest extends MouseSuite {
-  private val rightValue = List(42.asRight[String])
-  private val leftValue = List("42".asLeft[Int])
+  private val rightValue: Seq[Either[String, Int]] = List(42.asRight[String])
+  private val leftValue: Seq[Either[String, Int]] = List("42".asLeft[Int])
 
   test("FEitherSyntax.cata") {
     assertEquals(rightValue.cata(_ => 0, _ => 1), List(1))
@@ -108,6 +108,16 @@ class FEitherSyntaxTest extends MouseSuite {
     assertEquals(leftValue.leftMapIn(_ => ""), List("".asLeft[Int]))
   }
 
+  test("FEitherSyntax.leftAsIn") {
+    assertEquals(rightValue.leftAsIn(""), rightValue)
+    assertEquals(leftValue.leftAsIn(""), List("".asLeft[Int]))
+  }
+
+  test("FEitherSyntax.leftVoidIn") {
+    assertEquals(rightValue.leftVoidIn, rightValue.leftMapIn(_ => ()))
+    assertEquals(leftValue.leftVoidIn, List(().asLeft[Int]))
+  }
+
   test("FEitherSyntax.leftTraverseIn") {
     assertEquals(rightValue.leftTraverseIn(_ => Option("")), List(Option(42.asRight[String])))
     assertEquals(leftValue.leftTraverseIn(_ => Option("")), List(Option("".asLeft[Int])))
@@ -121,6 +131,16 @@ class FEitherSyntaxTest extends MouseSuite {
   test("FEitherSyntax.mapIn") {
     assertEquals(rightValue.mapIn(_ * 2), List(84.asRight[String]))
     assertEquals(leftValue.mapIn(_ * 2), leftValue)
+  }
+
+  test("FEitherSyntax.asIn") {
+    assertEquals(rightValue.asIn(2), List(2.asRight[String]))
+    assertEquals(leftValue.asIn(2), leftValue)
+  }
+
+  test("FEitherSyntax.voidIn") {
+    assertEquals(rightValue.voidIn, List(().asRight[String]))
+    assertEquals(leftValue.voidIn, leftValue.mapIn(_ => ()))
   }
 
   test("FEitherSyntax.orElseIn") {

--- a/shared/src/test/scala/mouse/FEitherSyntaxTest.scala
+++ b/shared/src/test/scala/mouse/FEitherSyntaxTest.scala
@@ -27,8 +27,8 @@ import cats.syntax.either._
 import scala.util.{Failure, Success, Try}
 
 class FEitherSyntaxTest extends MouseSuite {
-  private val rightValue: Seq[Either[String, Int]] = List(42.asRight[String])
-  private val leftValue: Seq[Either[String, Int]] = List("42".asLeft[Int])
+  private val rightValue = List(42.asRight[String])
+  private val leftValue = List("42".asLeft[Int])
 
   test("FEitherSyntax.cata") {
     assertEquals(rightValue.cata(_ => 0, _ => 1), List(1))

--- a/shared/src/test/scala/mouse/FOptionSyntaxTest.scala
+++ b/shared/src/test/scala/mouse/FOptionSyntaxTest.scala
@@ -125,6 +125,16 @@ class FOptionSyntaxTest extends MouseSuite {
     assertEquals(List(Option.empty[Int]).mapIn(_ + 1), List(Option.empty[Int]))
   }
 
+  test("FOptionSyntax.asIn") {
+    assertEquals(List(Option(1)).asIn(1), List(Option(1)))
+    assertEquals(List(Option.empty[Int]).asIn(1), List(Option.empty[Int]))
+  }
+
+  test("FOptionSyntax.voidIn") {
+    assertEquals(List(Option(1)).voidIn, List(Option(())))
+    assertEquals(List(Option.empty[Int]).voidIn, List(Option.empty[Unit]))
+  }
+
   test("FOptionSyntax.orElseIn") {
     assertEquals(List(Option(1)).orElseIn(Option(0)), List(Option(1)))
     assertEquals(List(Option.empty[Int]).orElseIn(Option(0)), List(Option(0)))


### PR DESCRIPTION
Hi guys! This PR adds some useful methods based on `mapIn` and `leftMapIn`.

**F[Option[A]]**
- `asIn` -> map `F[Option[A]]`  to `F[Option[B]]` ignoring the `A` value.
- `voidIn` -> drain `F[Option[A]]`  to `F[Option[Unit]]` ignoring the `A` value.

**F[Either[L, R]]**
- `asIn` -> map `F[Either[L, R]]`  to `F[Either[L, B]]` ignoring the `R` value.
- `voidIn` -> drain `F[Either[L, R]]`  to `F[Either[L, Unit]]` ignoring the `R` value.
- `leftAsIn`  -> map `F[Either[L, R]]`  to `F[Either[B, R]]` ignoring the `L` value.
- `leftVoidIn` -> drain `F[Either[L, R]]`  to `F[Either[Unit, R]]` ignoring the `L` value.

What do you think ? 