### PR TITLE
Add getOrRethrow into feither

### DIFF
--- a/shared/src/main/scala/mouse/feither.scala
+++ b/shared/src/main/scala/mouse/feither.scala
@@ -63,7 +63,10 @@ final class FEitherOps[F[_], L, R](private val felr: F[Either[L, R]]) extends An
   def getOrElseIn[A >: R](right: => A)(implicit F: Functor[F]): F[A] =
     F.map(felr)(_.fold(_ => right, identity))
 
-  def getOrRaise[E](e: => E)(implicit F: MonadError[F, _ >: E]): F[R] =
+  def getOrRethrow(implicit F: MonadThrow[F], env: L <:< Throwable): F[R] =
+    foldF(e => F.raiseError[R](e))(F.pure)
+
+  def getOrRaise[E](e: => E)(implicit F: MonadError[F, ? >: E]): F[R] =
     getOrElseF(F.raiseError(e))
 
   def getOrRaiseMsg(msg: => String)(implicit F: MonadThrow[F]): F[R] =

--- a/shared/src/test/scala/mouse/FEitherSyntaxTest.scala
+++ b/shared/src/test/scala/mouse/FEitherSyntaxTest.scala
@@ -72,7 +72,7 @@ class FEitherSyntaxTest extends MouseSuite {
     assertEquals(leftValue.getOrElseIn(0), List(0))
   }
 
-  test("FEitherSyntax.getOrRethrow"){
+  test("FEitherSyntax.getOrRethrow") {
     val ex1 = new RuntimeException("BOOM 1!")
     assertEquals(Try(1.asRight).getOrRethrow, Success(1))
     assertEquals(Try(ex1.asLeft).getOrRethrow, Failure(ex1))

--- a/shared/src/test/scala/mouse/FEitherSyntaxTest.scala
+++ b/shared/src/test/scala/mouse/FEitherSyntaxTest.scala
@@ -72,6 +72,13 @@ class FEitherSyntaxTest extends MouseSuite {
     assertEquals(leftValue.getOrElseIn(0), List(0))
   }
 
+  test("FEitherSyntax.getOrRethrow"){
+    val ex1 = new RuntimeException("BOOM 1!")
+    assertEquals(Try(1.asRight).getOrRethrow, Success(1))
+    assertEquals(Try(ex1.asLeft).getOrRethrow, Failure(ex1))
+    assertEquals(Try[Either[Throwable, Int]](throw ex1).getOrRethrow, Failure(ex1))
+  }
+
   test("FEitherSyntax.getOrRaise") {
     val ex1 = new RuntimeException("BOOM 1!")
     val ex2 = new RuntimeException("BOOM 2!")


### PR DESCRIPTION
Hi guys! This PR adds one useful method to re-throw an exception wrapped as `Left` into an `F` where a `MonadThrow` is available.

I'm not sure about the naming, I'd like to continue using "raise" instead of "throw" but I named it "rethrow" because it's also present into `EitherT`. 
Other alternatives that came to mind are:
- getOrRaise ( overload of the existent method ) 
- getOrReRaise 

Example
```scala
val result: Try[Int] = Try(new RuntimeException("BOOM!").asLeft[Int]).getOrRethrow    
```
