### PR TITLE
Add asRightIn, asLeftIn and asSomeIn for anyF

### DIFF
--- a/shared/src/main/scala/mouse/anyf.scala
+++ b/shared/src/main/scala/mouse/anyf.scala
@@ -34,13 +34,13 @@ final class AnyFOps[F[_], A](private val fa: F[A]) extends AnyVal {
   @inline def ||>[G[_]](f: F ~> G): G[A] = f(fa)
   @inline def thrushK[G[_]](f: F ~> G): G[A] = f(fa)
 
-  def asRightIn[L](implicit F: Functor[F]): F[Either[L, A]] =
+  def mapAsRight[L](implicit F: Functor[F]): F[Either[L, A]] =
     Functor[F].map(fa)(Right(_))
 
-  def asLeftIn[R](implicit F: Functor[F]): F[Either[A, R]] =
+  def mapAsLeft[R](implicit F: Functor[F]): F[Either[A, R]] =
     Functor[F].map(fa)(Left(_))
 
-  def asSomeIn(implicit F: Functor[F]): F[Option[A]] =
+  def mapAsSome(implicit F: Functor[F]): F[Option[A]] =
     Functor[F].map(fa)(Some(_))
 
   def liftEitherT[E](implicit F: Functor[F]): EitherT[F, E, A] =

--- a/shared/src/main/scala/mouse/anyf.scala
+++ b/shared/src/main/scala/mouse/anyf.scala
@@ -34,6 +34,15 @@ final class AnyFOps[F[_], A](private val fa: F[A]) extends AnyVal {
   @inline def ||>[G[_]](f: F ~> G): G[A] = f(fa)
   @inline def thrushK[G[_]](f: F ~> G): G[A] = f(fa)
 
+  def asRightIn[L](implicit F: Functor[F]): F[Either[L, A]] =
+    Functor[F].map(fa)(Right(_))
+
+  def asLeftIn[R](implicit F: Functor[F]): F[Either[A, R]] =
+    Functor[F].map(fa)(Left(_))
+
+  def asSomeIn(implicit F: Functor[F]): F[Option[A]] =
+    Functor[F].map(fa)(Some(_))
+
   def liftEitherT[E](implicit F: Functor[F]): EitherT[F, E, A] =
     EitherT.right[E](fa)
 

--- a/shared/src/test/scala/mouse/AnyFSyntaxTest.scala
+++ b/shared/src/test/scala/mouse/AnyFSyntaxTest.scala
@@ -63,6 +63,18 @@ class AnyFSyntaxTest extends MouseSuite {
     )
   }
 
+  test("AnyFSyntax.asRightIn") {
+    assertEquals(List(1).asRightIn[String], List(1.asRight))
+  }
+
+  test("AnyFSyntax.asLeftIn") {
+    assertEquals(List(1).asLeftIn[String], List(1.asLeft))
+  }
+
+  test("AnyFSyntax.asSomeIn") {
+    assertEquals(List(1).asSomeIn, List(1.some))
+  }
+
   test("AnyFSyntax.liftEitherT") {
     assertEquals(List(1).liftEitherT[String], EitherT(List(1.asRight[String])))
   }

--- a/shared/src/test/scala/mouse/AnyFSyntaxTest.scala
+++ b/shared/src/test/scala/mouse/AnyFSyntaxTest.scala
@@ -64,15 +64,15 @@ class AnyFSyntaxTest extends MouseSuite {
   }
 
   test("AnyFSyntax.asRightIn") {
-    assertEquals(List(1).asRightIn[String], List(1.asRight))
+    assertEquals(List(1).mapAsRight[String], List(1.asRight))
   }
 
   test("AnyFSyntax.asLeftIn") {
-    assertEquals(List(1).asLeftIn[String], List(1.asLeft))
+    assertEquals(List(1).mapAsLeft[String], List(1.asLeft))
   }
 
   test("AnyFSyntax.asSomeIn") {
-    assertEquals(List(1).asSomeIn, List(1.some))
+    assertEquals(List(1).mapAsSome, List(1.some))
   }
 
   test("AnyFSyntax.liftEitherT") {


### PR DESCRIPTION
Hi guys! This PR adds some methods to map an `F[A]` into `F[Either[L, A]]`, `F[Either[A, R]]` or `F[Option[A]]`.

Example
```scala
val fa: IO[Int] = IO.pure(1)

val faRight: IO[Either[String, Int]] = fa.asRightIn[String]
val faLeft: IO[Either[Int, String]] = fa.asLeftIn[String]
val faOption: IO[Option[Int]] = fa.asSomeIn
```

And for the naming, here a recap
```scala

val a: Int = 1 
val fa: IO[Int] = IO.pure(a)

val right: Either[String, Int] = a.asRight[String]
val faRightFromA: IO[Either[String, Int]] = a.asRightF[IO, String]
val faRightFromFA: IO[Either[String, Int]] = fa.mapAsRight[String]
```

What do you think ? Is there already something in place that I didn't found ? If not, do you think the name is coherent ? 