### PR TITLE
Add `leftMapOrKeepIn` / `leftFlatMapOrKeepIn` to `F[Either[A,B]]` syntax

### DIFF
--- a/shared/src/main/scala/mouse/feither.scala
+++ b/shared/src/main/scala/mouse/feither.scala
@@ -93,6 +93,12 @@ final class FEitherOps[F[_], L, R](private val felr: F[Either[L, R]]) extends An
       case r @ Right(_) => r.asInstanceOf[Right[A, R]]
     }
 
+  def leftMapOrKeepIn[LL >: L](pf: PartialFunction[L, LL])(implicit F: Functor[F]): F[Either[LL, R]] =
+    F.map(felr) {
+      case Left(a)        => Left(pf.applyOrElse(a, identity[LL]))
+      case r: Right[L, R] => r.asInstanceOf[Right[LL, R]]
+    }
+
   def leftAsIn[B](b: => B)(implicit F: Functor[F]): F[Either[B, R]] =
     leftMapIn(_ => b)
 

--- a/shared/src/main/scala/mouse/feither.scala
+++ b/shared/src/main/scala/mouse/feither.scala
@@ -81,6 +81,14 @@ final class FEitherOps[F[_], L, R](private val felr: F[Either[L, R]]) extends An
       case r @ Right(_) => r.asInstanceOf[Right[A, B]]
     }
 
+  def leftFlatMapOrKeepIn[LL >: L, RR >: R](
+    pf: PartialFunction[L, Either[LL, RR]]
+  )(implicit F: Functor[F]): F[Either[LL, RR]] =
+    F.map(felr) {
+      case l @ Left(a)    => pf.applyOrElse(a, (_: L) => l)
+      case r: Right[L, R] => r.asInstanceOf[Right[LL, RR]]
+    }
+
   def leftFlatMapF[A, B >: R](f: L => F[Either[A, B]])(implicit F: Monad[F]): F[Either[A, B]] =
     F.flatMap(felr) {
       case Left(left)   => f(left)

--- a/shared/src/test/scala/mouse/FEitherSyntaxTest.scala
+++ b/shared/src/test/scala/mouse/FEitherSyntaxTest.scala
@@ -114,6 +114,12 @@ class FEitherSyntaxTest extends MouseSuite {
     assertEquals(leftValue.leftMapIn(_ => ""), List("".asLeft[Int]))
   }
 
+  test("FEitherSyntax.leftMapOrKeepIn") {
+    assertEquals(rightValue.leftMapOrKeepIn { case "42" => "" }, rightValue)
+    assertEquals(leftValue.leftMapOrKeepIn { case "4242" => "" }, leftValue)
+    assertEquals(leftValue.leftMapOrKeepIn { case "42" => "" }, List(Left("")))
+  }
+
   test("FEitherSyntax.leftAsIn") {
     assertEquals(rightValue.leftAsIn(""), rightValue)
     assertEquals(leftValue.leftAsIn(""), List("".asLeft[Int]))

--- a/shared/src/test/scala/mouse/FEitherSyntaxTest.scala
+++ b/shared/src/test/scala/mouse/FEitherSyntaxTest.scala
@@ -104,6 +104,13 @@ class FEitherSyntaxTest extends MouseSuite {
     assertEquals(leftValue.leftFlatMapIn(_ => "".asLeft[Int]), List("".asLeft[Int]))
   }
 
+  test("FEitherSyntax.leftFlatMapOrKeepIn") {
+    assertEquals(rightValue.leftFlatMapOrKeepIn { case "42" => Left("") }, rightValue)
+    assertEquals(leftValue.leftFlatMapOrKeepIn { case "4242" => Right(42) }, leftValue)
+    assertEquals(leftValue.leftFlatMapOrKeepIn { case "42" => Left("") }, List(Left("")))
+    assertEquals(leftValue.leftFlatMapOrKeepIn { case "42" => Right(42) }, rightValue)
+  }
+
   test("FEitherSyntax.leftFlatMapF") {
     assertEquals(rightValue.leftFlatMapF(_ => List("".asLeft[Int])), rightValue)
     assertEquals(leftValue.leftFlatMapF(_ => List("".asLeft[Int])), List("".asLeft[Int]))


### PR DESCRIPTION
It's a companion PR to https://github.com/typelevel/cats/pull/4638