### PR TITLE
Add Boolean.otherwise and AnyF.withFilter for MonadError for-comprehension guards

### DIFF
--- a/shared/src/main/scala/mouse/anyf.scala
+++ b/shared/src/main/scala/mouse/anyf.scala
@@ -23,8 +23,7 @@ package mouse
 
 import cats.data.EitherT
 import cats.data.OptionT
-import cats.~>
-import cats.Functor
+import cats.{~>, Functor, MonadError}
 
 trait AnyFSyntax {
   implicit final def anyfSyntaxMouse[F[_], A](fa: F[A]): AnyFOps[F, A] = new AnyFOps(fa)
@@ -48,5 +47,8 @@ final class AnyFOps[F[_], A](private val fa: F[A]) extends AnyVal {
 
   def liftOptionT(implicit F: Functor[F]): OptionT[F, A] =
     OptionT.liftF(fa)
+
+  def withFilter[E](f: A => F[Unit])(implicit F: MonadError[F, E]): F[A] =
+    F.flatMap(fa)(a => F.as(f(a), a))
 
 }

--- a/shared/src/main/scala/mouse/boolean.scala
+++ b/shared/src/main/scala/mouse/boolean.scala
@@ -89,6 +89,8 @@ final class BooleanOps(private val b: Boolean) extends AnyVal {
 
   @inline def liftTo[F[_]]: LiftToPartiallyApplied[F] = new LiftToPartiallyApplied(b)
 
+  @inline def otherwise[F[_], E](e: => E)(implicit F: ApplicativeError[F, E]): F[Unit] = F.raiseUnless(b)(e)
+
 }
 
 object BooleanSyntax {

--- a/shared/src/test/scala/mouse/AnyFSyntaxTest.scala
+++ b/shared/src/test/scala/mouse/AnyFSyntaxTest.scala
@@ -89,5 +89,14 @@ class AnyFSyntaxTest extends MouseSuite {
     assertEquals(1.asRight[String].withFilter(_ => "rejected".asLeft[Unit]), "rejected".asLeft[Int])
 
     assertEquals("error".asLeft[Int].withFilter(_ => ().asRight[String]), "error".asLeft[Int])
+
+    // `if <x>` desugars to `.withFilter(<x>)` inside a for-expr.
+    // This test case asserts that AnyFSyntax.withFilter can be used in
+    // for-expressions over MonadError types such as Either.
+    val result = for {
+      age <- 15.asRight[String]
+      if (age >= 18).otherwise("Age must be at least 18")
+    } yield age
+    assertEquals(result, Left("Age must be at least 18"))
   }
 }

--- a/shared/src/test/scala/mouse/AnyFSyntaxTest.scala
+++ b/shared/src/test/scala/mouse/AnyFSyntaxTest.scala
@@ -82,4 +82,12 @@ class AnyFSyntaxTest extends MouseSuite {
   test("AnyFSyntax.liftOptionT") {
     assertEquals(List(1).liftOptionT, OptionT(List(Option(1))))
   }
+
+  test("AnyFSyntax.withFilter") {
+    assertEquals(1.asRight[String].withFilter(_ => ().asRight[String]), 1.asRight[String])
+
+    assertEquals(1.asRight[String].withFilter(_ => "rejected".asLeft[Unit]), "rejected".asLeft[Int])
+
+    assertEquals("error".asLeft[Int].withFilter(_ => ().asRight[String]), "error".asLeft[Int])
+  }
 }

--- a/shared/src/test/scala/mouse/BooleanSyntaxTest.scala
+++ b/shared/src/test/scala/mouse/BooleanSyntaxTest.scala
@@ -136,4 +136,12 @@ class BooleanSyntaxTest extends MouseSuite {
     )
     assertEquals(lazinessChecker, 0)
   }
+
+  test("BooleanSyntax.otherwise") {
+    type E = String
+    type F[A] = Either[E, A]
+
+    assertEquals(true.otherwise[F, E]("error"), Either.right(()))
+    assertEquals(false.otherwise[F, E]("error"), Either.left("error"))
+  }
 }


### PR DESCRIPTION
Adds two methods:
_otherwise_ on BooleanOps -  raises an error in any ApplicativeError context if the boolean is false.

_withFilter_ on AnyFOps - enables filtering on MonadError types like Either. 

These enable the use of typed 'if' guards in for-comprehensions over MonadError types, which is the main motivator behind this PR. For instance, instead of writing:

```scala
    for {
      age <- parseAge(age)
      _   <- F.raiseUnless(age >= 18)("age must be at least 18")
    } yield age
```
We can write:
```scala
    for {
      age <- parseAge(age)
      if (age >= 18) otherwise "Age must be at least 18"
    } yield age

```